### PR TITLE
[feat] 회원 정보 수정

### DIFF
--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/SecurityConfig.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/SecurityConfig.kt
@@ -1,15 +1,17 @@
 package com.example.enterparkticket.apis.enduser.config
 
+import com.example.enterparkticket.apis.enduser.config.jwt.JwtTokenFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(private val jwtTokenFilter: JwtTokenFilter) {
 
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
@@ -20,6 +22,7 @@ class SecurityConfig {
                 it.requestMatchers("/v1/auth/oauth/**").permitAll()
                 it.anyRequest().authenticated()
             }
+            .addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter::class.java)
             .build()
     }
 }

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/jwt/dto/AuthDetails.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/jwt/dto/AuthDetails.kt
@@ -23,3 +23,7 @@ class AuthDetails(
         return userId
     }
 }
+
+fun AuthDetails.toUserId(): Long {
+    return this.username.toLong()
+}

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/jwt/dto/AuthUser.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/jwt/dto/AuthUser.kt
@@ -1,0 +1,8 @@
+package com.example.enterparkticket.apis.enduser.config.jwt.dto
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@AuthenticationPrincipal
+annotation class AuthUser

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/oauth/dto/KakaoTokenResponse.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/oauth/dto/KakaoTokenResponse.kt
@@ -1,5 +1,6 @@
 package com.example.enterparkticket.apis.enduser.config.oauth.dto
 
+import com.example.enterparkticket.core.domain.user.service.dto.KakaoTokenDto
 import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 
@@ -10,4 +11,9 @@ data class KakaoTokenResponse(
     val expiresIn: Int,
     val refreshToken: String,
     val refreshTokenExpiresIn: Int,
-)
+) {
+
+    fun toKakaoTokenDto(): KakaoTokenDto {
+        return KakaoTokenDto(tokenType, accessToken, expiresIn, refreshToken, refreshTokenExpiresIn)
+    }
+}

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/user/controller/UserController.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/user/controller/UserController.kt
@@ -1,0 +1,29 @@
+package com.example.enterparkticket.apis.enduser.user.controller
+
+import com.example.enterparkticket.apis.enduser.config.jwt.dto.AuthDetails
+import com.example.enterparkticket.apis.enduser.config.jwt.dto.AuthUser
+import com.example.enterparkticket.apis.enduser.config.jwt.dto.toUserId
+import com.example.enterparkticket.apis.enduser.user.dto.request.UpdateUserRequest
+import com.example.enterparkticket.apis.enduser.user.service.UpdateUseCase
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Validated
+@RestController
+@RequestMapping("/v1/users")
+class UserController(private val updateUseCase: UpdateUseCase) {
+
+    @PatchMapping("/update")
+    fun updateUser(
+        @AuthUser user: AuthDetails,
+        @Valid @RequestBody request: UpdateUserRequest,
+    ): ResponseEntity<String> {
+        updateUseCase.updateUser(user.toUserId(), request)
+        return ResponseEntity.ok("회원 정보 수정이 완료되었습니다.")
+    }
+}

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/user/dto/request/UpdateUserRequest.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/user/dto/request/UpdateUserRequest.kt
@@ -1,0 +1,30 @@
+package com.example.enterparkticket.apis.enduser.user.dto.request
+
+import com.example.enterparkticket.core.domain.user.service.dto.UpdateUserDto
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+data class UpdateUserRequest(
+
+    @field:NotBlank(message = "이름은 필수 입력입니다.")
+    @field:Size(min = 1, max = 20, message = "이름은 1~20자만 가능합니다.")
+    val name: String,
+
+    @field:NotBlank(message = "전화번호는 필수 입력입니다.")
+    @field:Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "전화번호 양식에 맞지 않습니다.")
+    val phoneNumber: String,
+
+    @field:Size(max = 255, message = "배송지는 0~255자만 가능합니다.")
+    val address: String?,
+) {
+
+    fun toUpdateUserDto(email: String): UpdateUserDto {
+        return UpdateUserDto(
+            name,
+            email,
+            phoneNumber,
+            address,
+        )
+    }
+}

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/user/service/UpdateUseCase.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/user/service/UpdateUseCase.kt
@@ -1,0 +1,20 @@
+package com.example.enterparkticket.apis.enduser.user.service
+
+import com.example.enterparkticket.apis.enduser.auth.service.helper.KakaoOAuthHelper
+import com.example.enterparkticket.apis.enduser.user.dto.request.UpdateUserRequest
+import com.example.enterparkticket.core.domain.user.service.UserDomainService
+import org.springframework.stereotype.Service
+
+@Service
+class UpdateUseCase(
+    private val userDomainService: UserDomainService,
+    private val kakaoOAuthHelper: KakaoOAuthHelper,
+) {
+
+    fun updateUser(userId: Long, request: UpdateUserRequest) {
+        val user = userDomainService.findUserById(userId)
+        val accessToken = kakaoOAuthHelper.getToken(user.oAuthInfo.oid)
+        val userInfo = kakaoOAuthHelper.getUserInfo(accessToken)
+        userDomainService.updateUser(userId, request.toUpdateUserDto(userInfo.kakaoAccount.email))
+    }
+}

--- a/enterpark-ticket-core/domain/build.gradle.kts
+++ b/enterpark-ticket-core/domain/build.gradle.kts
@@ -8,6 +8,8 @@ jar.enabled = true
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
     implementation("org.flywaydb:flyway-mysql")
     runtimeOnly("com.mysql:mysql-connector-j")
     runtimeOnly("com.h2database:h2")

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/consts/EnterparkTicketConsts.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/consts/EnterparkTicketConsts.kt
@@ -8,4 +8,6 @@ object EnterparkTicketConsts {
     const val NOT_FOUND = 404
     const val CONFLICT = 409
     const val INTERNAL_SERVER_ERROR = 500
+
+    const val KAKAO_TOKEN_PREFIX = "kakaoToken:"
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/EnterparkTicketConfigGroup.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/EnterparkTicketConfigGroup.kt
@@ -1,7 +1,9 @@
 package com.example.enterparkticket.core.domain.config
 
 import com.example.enterparkticket.core.domain.config.jpa.JpaConfig
+import com.example.enterparkticket.core.domain.config.redis.RedisConfig
 
 enum class EnterparkTicketConfigGroup(val configClass: Class<out EnterparkTicketConfig>) {
     JPA(JpaConfig::class.java),
+    REDIS(RedisConfig::class.java),
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/InfraConfig.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/InfraConfig.kt
@@ -1,9 +1,9 @@
 package com.example.enterparkticket.core.domain.config
 
-import com.example.enterparkticket.core.domain.config.EnterparkTicketConfigGroup.JPA
+import com.example.enterparkticket.core.domain.config.EnterparkTicketConfigGroup.*
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@EnableEnterparkTicketConfig([JPA])
+@EnableEnterparkTicketConfig([JPA, REDIS])
 class InfraConfig {
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/redis/RedisConfig.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/redis/RedisConfig.kt
@@ -1,0 +1,42 @@
+package com.example.enterparkticket.core.domain.config.redis
+
+import com.example.enterparkticket.core.domain.config.EnterparkTicketConfig
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Bean
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.RedisPassword
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import org.springframework.transaction.annotation.EnableTransactionManagement
+
+@EnableTransactionManagement
+@EntityScan(basePackages = ["com.example.enterparkticket"])
+class RedisConfig(
+    @Value("\${spring.data.redis.host}")
+    private val host: String,
+    @Value("\${spring.data.redis.port}")
+    private val port: Int,
+    @Value("\${spring.data.redis.password}")
+    private val password: String,
+) : EnterparkTicketConfig {
+
+    @Bean
+    fun customRedisConnectionFactory(): RedisConnectionFactory {
+        val config = RedisStandaloneConfiguration(host, port).apply {
+            password = RedisPassword.of(this@RedisConfig.password)
+        }
+        return LettuceConnectionFactory(config)
+    }
+
+    @Bean
+    fun customRedisTemplate(): RedisTemplate<String, Any> {
+        return RedisTemplate<String, Any>().apply {
+            connectionFactory = customRedisConnectionFactory()
+            keySerializer = StringRedisSerializer()
+            valueSerializer = StringRedisSerializer()
+        }
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/domain/User.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/domain/User.kt
@@ -47,4 +47,12 @@ class User(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     var id: Long? = null,
-) : BaseTimeEntity()
+) : BaseTimeEntity() {
+
+    fun updateUser(name: String, email: String, phoneNumber: String, address: String?) {
+        this.name = name
+        this.email = email
+        this.phoneNumber = phoneNumber
+        this.address = address
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/NotFoundKakaoTokenException.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/NotFoundKakaoTokenException.kt
@@ -1,0 +1,6 @@
+package com.example.enterparkticket.core.domain.user.exception
+
+import com.example.enterparkticket.core.domain.common.exeption.EnterparkTicketException
+
+class NotFoundKakaoTokenException : EnterparkTicketException(UserErrorCode.KAKAO_TOKEN_NOT_FOUND) {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/NotFoundUserException.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/NotFoundUserException.kt
@@ -1,0 +1,6 @@
+package com.example.enterparkticket.core.domain.user.exception
+
+import com.example.enterparkticket.core.domain.common.exeption.EnterparkTicketException
+
+class NotFoundUserException : EnterparkTicketException(UserErrorCode.USER_NOT_FOUND) {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/UserErrorCode.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/UserErrorCode.kt
@@ -8,7 +8,8 @@ import com.example.enterparkticket.core.domain.common.exeption.ErrorDescription
 enum class UserErrorCode(private val status: Int, private val message: String) : BaseErrorCode {
 
     USER_ALREADY_REGISTER(CONFLICT, "이미 존재하는 회원입니다."),
-    USER_NOT_FOUND(NOT_FOUND, "존재하지 않는 회원입니다.");
+    USER_NOT_FOUND(NOT_FOUND, "존재하지 않는 회원입니다."),
+    KAKAO_TOKEN_NOT_FOUND(NOT_FOUND, "해당 회원의 카카오 토큰이 존재하지 않습니다.");
 
     override fun getErrorDescription(): ErrorDescription {
         return ErrorDescription(name, message, status)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/UserErrorCode.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/UserErrorCode.kt
@@ -1,12 +1,14 @@
 package com.example.enterparkticket.core.domain.user.exception
 
 import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.CONFLICT
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.NOT_FOUND
 import com.example.enterparkticket.core.domain.common.exeption.BaseErrorCode
 import com.example.enterparkticket.core.domain.common.exeption.ErrorDescription
 
 enum class UserErrorCode(private val status: Int, private val message: String) : BaseErrorCode {
 
-    USER_ALREADY_REGISTER(CONFLICT, "이미 존재하는 회원입니다.");
+    USER_ALREADY_REGISTER(CONFLICT, "이미 존재하는 회원입니다."),
+    USER_NOT_FOUND(NOT_FOUND, "존재하지 않는 회원입니다.");
 
     override fun getErrorDescription(): ErrorDescription {
         return ErrorDescription(name, message, status)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/KakaoTokenService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/KakaoTokenService.kt
@@ -1,0 +1,28 @@
+package com.example.enterparkticket.core.domain.user.service
+
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.KAKAO_TOKEN_PREFIX
+import com.example.enterparkticket.core.domain.user.exception.NotFoundKakaoTokenException
+import com.example.enterparkticket.core.domain.user.service.dto.KakaoTokenDto
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import java.util.concurrent.TimeUnit
+
+@Service
+class KakaoTokenService(private val redisTemplate: RedisTemplate<String, String>) {
+
+    fun saveToken(oAuthId: Long, dto: KakaoTokenDto) {
+        val key = KAKAO_TOKEN_PREFIX + oAuthId
+        redisTemplate.opsForValue()
+            .set(key, dto.accessToken, dto.expiresIn * 1000L, TimeUnit.MILLISECONDS)
+    }
+
+    fun getToken(oAuthId: Long): String {
+        val key = KAKAO_TOKEN_PREFIX + oAuthId
+        val value = redisTemplate.opsForValue()[key]
+        return if (!value.isNullOrEmpty()) {
+            value
+        } else {
+            throw NotFoundKakaoTokenException()
+        }
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/UserDomainService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/UserDomainService.kt
@@ -3,12 +3,15 @@ package com.example.enterparkticket.core.domain.user.service
 import com.example.enterparkticket.core.domain.user.domain.OAuthInfo
 import com.example.enterparkticket.core.domain.user.domain.User
 import com.example.enterparkticket.core.domain.user.exception.AlreadyRegisterUserException
+import com.example.enterparkticket.core.domain.user.exception.NotFoundUserException
 import com.example.enterparkticket.core.domain.user.repository.UserRepository
 import com.example.enterparkticket.core.domain.user.service.dto.RegisterUserDto
+import com.example.enterparkticket.core.domain.user.service.dto.UpdateUserDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
+@Transactional(readOnly = true)
 class UserDomainService(private val userRepository: UserRepository) {
 
     @Transactional
@@ -17,6 +20,18 @@ class UserDomainService(private val userRepository: UserRepository) {
         val user = dto.toUserEntity(oAuthInfo, email)
         userRepository.save(user)
         return user
+    }
+
+    @Transactional
+    fun updateUser(userId: Long, dto: UpdateUserDto) {
+        val user = findUserById(userId)
+        user.updateUser(dto.name, dto.email, dto.phoneNumber, dto.address)
+    }
+
+    fun findUserById(userId: Long): User {
+        return userRepository.findById(userId).orElseThrow {
+            NotFoundUserException()
+        }
     }
 
     private fun validateUser(oAuthInfo: OAuthInfo) {

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/dto/KakaoTokenDto.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/dto/KakaoTokenDto.kt
@@ -1,0 +1,9 @@
+package com.example.enterparkticket.core.domain.user.service.dto
+
+data class KakaoTokenDto(
+    val tokenType: String,
+    val accessToken: String,
+    val expiresIn: Int,
+    val refreshToken: String,
+    val refreshTokenExpiresIn: Int,
+)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/dto/UpdateUserDto.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/dto/UpdateUserDto.kt
@@ -1,0 +1,8 @@
+package com.example.enterparkticket.core.domain.user.service.dto
+
+data class UpdateUserDto(
+    val name: String,
+    val email: String,
+    val phoneNumber: String,
+    val address: String?,
+)

--- a/enterpark-ticket-core/domain/src/main/resources/application-domain.yml
+++ b/enterpark-ticket-core/domain/src/main/resources/application-domain.yml
@@ -18,6 +18,11 @@ spring:
     open-in-view: false
   flyway:
     enabled: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password:
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 📌 개요
- close #6 

## 💾 작업사항
- 회원가입이나 로그인에서 카카오 토큰 받아올 때 레디스에 저장
- 이름, 전화번호, 이메일, 배송지 변경 가능

## 🌠 기타 
- 카카오 어드민 키는 보안에 유의하여 사용해야 하므로 서버에서 호출할 때만 사용하는 것이 좋기 때문에, 액세스 토큰으로 사용자 정보를 가져오는 방식을 사용하였습니다.
- 기존 코드는 카카오 액세스 토큰은 회원가입이나 로그인 시 저장되는 곳이 없기 때문에, 레디스에 userid와 매핑하여 한시적으로 저장하여, 사용자 정보를 가져올 수 있도록 구현하였습니다.