### PR TITLE
[feat] 회원 탈퇴

### DIFF
--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/auth/controller/AuthController.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/auth/controller/AuthController.kt
@@ -3,6 +3,10 @@ package com.example.enterparkticket.apis.enduser.auth.controller
 import com.example.enterparkticket.apis.enduser.auth.dto.request.RegisterUserRequest
 import com.example.enterparkticket.apis.enduser.auth.dto.response.RegisterUserResponse
 import com.example.enterparkticket.apis.enduser.auth.service.RegisterUseCase
+import com.example.enterparkticket.apis.enduser.auth.service.WithdrawUseCase
+import com.example.enterparkticket.apis.enduser.config.jwt.dto.AuthDetails
+import com.example.enterparkticket.apis.enduser.config.jwt.dto.AuthUser
+import com.example.enterparkticket.apis.enduser.config.jwt.dto.toUserId
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.ResponseEntity
@@ -12,7 +16,10 @@ import org.springframework.web.bind.annotation.*
 @Validated
 @RestController
 @RequestMapping("/v1/auth")
-class AuthController(private val registerUseCase: RegisterUseCase) {
+class AuthController(
+    private val registerUseCase: RegisterUseCase,
+    private val withdrawUseCase: WithdrawUseCase,
+) {
 
     @PostMapping("/oauth/kakao/register")
     fun kakaoOAuthRegisterUser(
@@ -21,5 +28,11 @@ class AuthController(private val registerUseCase: RegisterUseCase) {
     ): ResponseEntity<RegisterUserResponse> {
         val response = registerUseCase.registerUser(code, request)
         return ResponseEntity.status(CREATED).body(response)
+    }
+
+    @PatchMapping("/oauth/kakao/withdrawal")
+    fun kakaoOAuthWithdrawUser(@AuthUser user: AuthDetails): ResponseEntity<String> {
+        withdrawUseCase.withdrawUser(user.toUserId())
+        return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.")
     }
 }

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/auth/service/WithdrawUseCase.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/auth/service/WithdrawUseCase.kt
@@ -1,0 +1,17 @@
+package com.example.enterparkticket.apis.enduser.auth.service
+
+import com.example.enterparkticket.apis.enduser.auth.service.helper.KakaoOAuthHelper
+import com.example.enterparkticket.core.domain.user.service.UserDomainService
+import org.springframework.stereotype.Service
+
+@Service
+class WithdrawUseCase(
+    private val userDomainService: UserDomainService,
+    private val kakaoOAuthHelper: KakaoOAuthHelper,
+) {
+
+    fun withdrawUser(userId: Long) {
+        val user = userDomainService.withdrawUser(userId)
+        kakaoOAuthHelper.unlinkUser(user.oAuthInfo.oid)
+    }
+}

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/auth/service/helper/KakaoOAuthHelper.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/auth/service/helper/KakaoOAuthHelper.kt
@@ -6,6 +6,8 @@ import com.example.enterparkticket.apis.enduser.config.oauth.dto.KakaoOAuthInfoE
 import com.example.enterparkticket.apis.enduser.config.oauth.dto.KakaoTokenRequest
 import com.example.enterparkticket.apis.enduser.config.oauth.dto.KakaoUserInfoResponse
 import com.example.enterparkticket.apis.enduser.config.oauth.properties.KakaoOAuthProperties
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.BEARER
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.KAKAO_AK
 import com.example.enterparkticket.core.domain.common.exeption.InvalidEmailException
 import com.example.enterparkticket.core.domain.user.domain.OAuthInfo
 import com.example.enterparkticket.core.domain.user.domain.OAuthProvider
@@ -39,13 +41,14 @@ class KakaoOAuthHelper(
         return userInfo
     }
 
+    fun unlinkUser(targetId: Long) {
+        kakaoUserClient.unlinkUser(KAKAO_AK + kakaoOAuthProperties.adminKey, targetId)
+        kakaoTokenService.deleteToken(targetId)
+    }
+
     private fun validateEmail(userInfo: KakaoUserInfoResponse) {
         if (!userInfo.kakaoAccount.isEmailValid || !userInfo.kakaoAccount.isEmailVerified) {
             throw InvalidEmailException()
         }
-    }
-
-    companion object {
-        const val BEARER = "Bearer "
     }
 }

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/oauth/client/KakaoUserClient.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/oauth/client/KakaoUserClient.kt
@@ -1,13 +1,23 @@
 package com.example.enterparkticket.apis.enduser.config.oauth.client
 
+import com.example.enterparkticket.apis.enduser.config.oauth.dto.KakaoUnlinkUserResponse
 import com.example.enterparkticket.apis.enduser.config.oauth.dto.KakaoUserInfoResponse
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
 
 @FeignClient(name = "KakaoUserClient", url = "https://kapi.kakao.com")
 interface KakaoUserClient {
 
     @GetMapping("/v2/user/me")
     fun getUserInfo(@RequestHeader("Authorization") accessToken: String): KakaoUserInfoResponse
+
+    @PostMapping("/v1/user/unlink")
+    fun unlinkUser(
+        @RequestHeader("Authorization") adminKey: String,
+        @RequestParam("target_id") targetId: Long,
+        @RequestParam("target_id_type") targetIdType: String = "user_id",
+    ): KakaoUnlinkUserResponse
 }

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/oauth/dto/KakaoUnlinkUserResponse.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/oauth/dto/KakaoUnlinkUserResponse.kt
@@ -1,0 +1,5 @@
+package com.example.enterparkticket.apis.enduser.config.oauth.dto
+
+data class KakaoUnlinkUserResponse(
+    val id: Long,
+)

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/oauth/properties/KakaoOAuthProperties.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/oauth/properties/KakaoOAuthProperties.kt
@@ -6,5 +6,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 data class KakaoOAuthProperties(
     val clientId: String,
     val redirectUri: String,
-    val clientSecret: String
+    val clientSecret: String,
+    val adminKey: String,
 )

--- a/enterpark-ticket-apis/enduser/src/main/resources/application.yml
+++ b/enterpark-ticket-apis/enduser/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: ${KAKAO_REDIRECT_URI}
+            admin-key: ${KAKAO_ADMIN_KEY}
     auth:
       jwt:
         secret-key: ${JWT_SECRET_KEY}

--- a/enterpark-ticket-batch/build.gradle.kts
+++ b/enterpark-ticket-batch/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-batch")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     testImplementation("org.springframework.batch:spring-batch-test")
-    implementation(project(":enterpark-ticket-core"))
+    implementation(project(":enterpark-ticket-core:domain"))
 }

--- a/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/BatchApplication.kt
+++ b/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/BatchApplication.kt
@@ -3,9 +3,9 @@ package com.example.enterparkticket.batch
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = ["com.example.enterparkticket"])
 class BatchApplication
 
 fun main(args: Array<String>) {
-//    runApplication<BatchApplication>(*args)
+    runApplication<BatchApplication>(*args)
 }

--- a/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/config/BatchAuditorProvider.kt
+++ b/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/config/BatchAuditorProvider.kt
@@ -1,0 +1,13 @@
+package com.example.enterparkticket.batch.config
+
+import com.example.enterparkticket.core.domain.config.jpa.AuditorProvider
+import com.example.enterparkticket.core.domain.user.domain.RoleType
+import org.springframework.stereotype.Component
+
+@Component
+class BatchAuditorProvider : AuditorProvider {
+
+    override fun getCurrentAuditor(): String? {
+        return RoleType.ADMIN.name
+    }
+}

--- a/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/config/BatchConfig.kt
+++ b/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/config/BatchConfig.kt
@@ -1,0 +1,41 @@
+package com.example.enterparkticket.batch.config
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.jdbc.DataSourceBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
+import org.springframework.jdbc.support.JdbcTransactionManager
+import org.springframework.transaction.PlatformTransactionManager
+import javax.sql.DataSource
+
+@Configuration
+class BatchConfig {
+
+    @Primary
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.batch")
+    fun batchDataSource(): DataSource {
+        return DataSourceBuilder.create().build()
+    }
+
+    @Primary
+    @Bean
+    fun batchTransactionManager(
+        @Qualifier("batchDataSource") dataSource: DataSource,
+    ): PlatformTransactionManager {
+        return JdbcTransactionManager(dataSource)
+    }
+
+    companion object {
+
+        @Bean
+        fun jobRegistryBeanPostProcessorRemover(): BeanDefinitionRegistryPostProcessor {
+            return BeanDefinitionRegistryPostProcessor { registry ->
+                registry.removeBeanDefinition("jobRegistryBeanPostProcessor")
+            }
+        }
+    }
+}

--- a/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/job/UserStateDeletedJobConfig.kt
+++ b/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/job/UserStateDeletedJobConfig.kt
@@ -4,6 +4,7 @@ import com.example.enterparkticket.core.domain.config.jpa.JpaConfig
 import com.example.enterparkticket.core.domain.config.jpa.JpaConfig.Companion.PRIMARY_ENTITY_MANAGER_FACTORY
 import com.example.enterparkticket.core.domain.config.jpa.JpaConfig.Companion.PRIMARY_TRANSACTION_MANAGER
 import com.example.enterparkticket.core.domain.user.domain.User
+import com.example.enterparkticket.core.domain.user.service.UserDomainService
 import jakarta.persistence.EntityManagerFactory
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.Step
@@ -38,6 +39,7 @@ class UserStateDeletedJobConfig(
     private val transactionManager: PlatformTransactionManager,
 
     private val jobRepository: JobRepository,
+    private val userDomainService: UserDomainService,
 ) {
 
     @Bean(JOB_NAME)
@@ -73,7 +75,7 @@ class UserStateDeletedJobConfig(
     @Bean(BEAN_PREFIX + "itemProcessor")
     fun itemProcessor(): ItemProcessor<User, User> {
         return ItemProcessor {
-            it.deleteUser()
+            userDomainService.deleteUser(it)
         }
     }
 

--- a/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/job/UserStateDeletedJobConfig.kt
+++ b/enterpark-ticket-batch/src/main/kotlin/com/example/enterparkticket/batch/job/UserStateDeletedJobConfig.kt
@@ -1,0 +1,91 @@
+package com.example.enterparkticket.batch.job
+
+import com.example.enterparkticket.core.domain.config.jpa.JpaConfig
+import com.example.enterparkticket.core.domain.config.jpa.JpaConfig.Companion.PRIMARY_ENTITY_MANAGER_FACTORY
+import com.example.enterparkticket.core.domain.config.jpa.JpaConfig.Companion.PRIMARY_TRANSACTION_MANAGER
+import com.example.enterparkticket.core.domain.user.domain.User
+import jakarta.persistence.EntityManagerFactory
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.configuration.annotation.JobScope
+import org.springframework.batch.core.configuration.annotation.StepScope
+import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.step.builder.StepBuilder
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.batch.item.database.JpaItemWriter
+import org.springframework.batch.item.database.JpaPagingItemReader
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.transaction.PlatformTransactionManager
+import java.time.LocalDate
+
+@Configuration
+@Import(JpaConfig::class)
+class UserStateDeletedJobConfig(
+
+    @Value("\${spring.batch.chunk-size}")
+    private val chunkSize: Int,
+
+    @Qualifier(PRIMARY_ENTITY_MANAGER_FACTORY)
+    private val entityManagerFactory: EntityManagerFactory,
+
+    @Qualifier(PRIMARY_TRANSACTION_MANAGER)
+    private val transactionManager: PlatformTransactionManager,
+
+    private val jobRepository: JobRepository,
+) {
+
+    @Bean(JOB_NAME)
+    fun job(): Job {
+        return JobBuilder(JOB_NAME, jobRepository)
+            .start(step())
+            .build()
+    }
+
+    @Bean(BEAN_PREFIX + "step")
+    @JobScope
+    fun step(): Step {
+        return StepBuilder(BEAN_PREFIX + "step", jobRepository)
+            .chunk<User, User>(chunkSize, transactionManager)
+            .reader(itemReader(null))
+            .processor(itemProcessor())
+            .writer(itemWriter())
+            .build()
+    }
+
+    @Bean(BEAN_PREFIX + "itemReader")
+    @StepScope
+    fun itemReader(@Value("#{jobParameters[date]}") date: LocalDate?): JpaPagingItemReader<User> {
+        return JpaPagingItemReaderBuilder<User>()
+            .name(BEAN_PREFIX + "itemReader")
+            .entityManagerFactory(entityManagerFactory)
+            .pageSize(chunkSize)
+            .queryString("SELECT u FROM User u WHERE DATE(u.deletedDate) < :date ORDER BY u.id ASC")
+            .parameterValues(mapOf("date" to date?.minusDays(7)))
+            .build()
+    }
+
+    @Bean(BEAN_PREFIX + "itemProcessor")
+    fun itemProcessor(): ItemProcessor<User, User> {
+        return ItemProcessor {
+            it.deleteUser()
+        }
+    }
+
+    @Bean(BEAN_PREFIX + "itemWriter")
+    fun itemWriter(): JpaItemWriter<User> {
+        return JpaItemWriter<User>().apply {
+            setEntityManagerFactory(entityManagerFactory)
+        }
+    }
+
+    companion object {
+        const val JOB_NAME = "유저상태탈퇴"
+        const val BEAN_PREFIX = JOB_NAME + "_"
+    }
+}

--- a/enterpark-ticket-batch/src/main/resources/application.yml
+++ b/enterpark-ticket-batch/src/main/resources/application.yml
@@ -3,6 +3,10 @@ spring:
     active: local
     include:
       - domain
+  batch:
+    job:
+      name: ${job.name:NONE}
+    chunk-size: ${CHUNK_SIZE:1000}
 ---
 spring:
   config:

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/consts/EnterparkTicketConsts.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/consts/EnterparkTicketConsts.kt
@@ -10,4 +10,6 @@ object EnterparkTicketConsts {
     const val INTERNAL_SERVER_ERROR = 500
 
     const val KAKAO_TOKEN_PREFIX = "kakaoToken:"
+    const val BEARER = "Bearer "
+    const val KAKAO_AK = "KakaoAK "
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/consts/EnterparkTicketConsts.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/consts/EnterparkTicketConsts.kt
@@ -13,5 +13,6 @@ object EnterparkTicketConsts {
     const val BEARER = "Bearer "
     const val KAKAO_AK = "KakaoAK "
 
+    const val PRIMARY_TRANSACTION_MANAGER = "primaryTransactionManager"
     const val BATCH_TRANSACTION_MANAGER = "batchTransactionManager"
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/consts/EnterparkTicketConsts.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/consts/EnterparkTicketConsts.kt
@@ -12,4 +12,6 @@ object EnterparkTicketConsts {
     const val KAKAO_TOKEN_PREFIX = "kakaoToken:"
     const val BEARER = "Bearer "
     const val KAKAO_AK = "KakaoAK "
+
+    const val BATCH_TRANSACTION_MANAGER = "batchTransactionManager"
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/jpa/JpaConfig.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/jpa/JpaConfig.kt
@@ -1,21 +1,79 @@
 package com.example.enterparkticket.core.domain.config.jpa
 
 import com.example.enterparkticket.core.domain.config.EnterparkTicketConfig
+import com.example.enterparkticket.core.domain.config.jpa.JpaConfig.Companion.PRIMARY_ENTITY_MANAGER_FACTORY
+import com.example.enterparkticket.core.domain.config.jpa.JpaConfig.Companion.PRIMARY_TRANSACTION_MANAGER
+import jakarta.persistence.EntityManagerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateSettings
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.jdbc.DataSourceBuilder
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.data.domain.AuditorAware
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.orm.jpa.JpaTransactionManager
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean
+import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.EnableTransactionManagement
+import javax.sql.DataSource
 
 @EnableTransactionManagement
 @EntityScan(basePackages = ["com.example.enterparkticket"])
-@EnableJpaRepositories(basePackages = ["com.example.enterparkticket"])
+@EnableJpaRepositories(
+    basePackages = ["com.example.enterparkticket"],
+    entityManagerFactoryRef = PRIMARY_ENTITY_MANAGER_FACTORY,
+    transactionManagerRef = PRIMARY_TRANSACTION_MANAGER,
+)
 @EnableJpaAuditing(auditorAwareRef = "securityAuditorAware")
-class JpaConfig : EnterparkTicketConfig {
+class JpaConfig(
+    private val jpaProperties: JpaProperties,
+    private val hibernateProperties: HibernateProperties,
+) : EnterparkTicketConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = PRIMARY_CONFIGURATION_PROPERTIES_PREFIX)
+    fun primaryDataSource(): DataSource {
+        return DataSourceBuilder.create().build()
+    }
+
+    @Bean
+    fun primaryEntityManagerFactory(
+        builder: EntityManagerFactoryBuilder,
+        @Qualifier(PRIMARY_DATASOURCE) dataSource: DataSource,
+    ): LocalContainerEntityManagerFactoryBean {
+        val properties = hibernateProperties.determineHibernateProperties(
+            jpaProperties.properties,
+            HibernateSettings()
+        )
+        return builder.dataSource(dataSource)
+            .packages("com.example.enterparkticket")
+            .persistenceUnit(PRIMARY_PERSISTENCE_UNIT)
+            .properties(properties)
+            .build()
+    }
+
+    @Bean
+    fun primaryTransactionManager(
+        @Qualifier(PRIMARY_ENTITY_MANAGER_FACTORY) entityManagerFactory: EntityManagerFactory,
+    ): PlatformTransactionManager {
+        return JpaTransactionManager(entityManagerFactory)
+    }
 
     @Bean
     fun securityAuditorAware(auditorProvider: AuditorProvider): AuditorAware<String> {
         return SecurityAuditorAware(auditorProvider)
+    }
+
+    companion object {
+        const val PRIMARY_CONFIGURATION_PROPERTIES_PREFIX = "spring.datasource.primary"
+        const val PRIMARY_PERSISTENCE_UNIT = "primaryPersistenceUnit"
+        const val PRIMARY_DATASOURCE = "primaryDataSource"
+        const val PRIMARY_ENTITY_MANAGER_FACTORY = "primaryEntityManagerFactory"
+        const val PRIMARY_TRANSACTION_MANAGER = "primaryTransactionManager"
     }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/jpa/JpaConfig.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/jpa/JpaConfig.kt
@@ -1,8 +1,8 @@
 package com.example.enterparkticket.core.domain.config.jpa
 
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.PRIMARY_TRANSACTION_MANAGER
 import com.example.enterparkticket.core.domain.config.EnterparkTicketConfig
 import com.example.enterparkticket.core.domain.config.jpa.JpaConfig.Companion.PRIMARY_ENTITY_MANAGER_FACTORY
-import com.example.enterparkticket.core.domain.config.jpa.JpaConfig.Companion.PRIMARY_TRANSACTION_MANAGER
 import jakarta.persistence.EntityManagerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.domain.EntityScan
@@ -74,6 +74,5 @@ class JpaConfig(
         const val PRIMARY_PERSISTENCE_UNIT = "primaryPersistenceUnit"
         const val PRIMARY_DATASOURCE = "primaryDataSource"
         const val PRIMARY_ENTITY_MANAGER_FACTORY = "primaryEntityManagerFactory"
-        const val PRIMARY_TRANSACTION_MANAGER = "primaryTransactionManager"
     }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/domain/User.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/domain/User.kt
@@ -67,4 +67,9 @@ class User(
             throw ReRegisterUserException()
         }
     }
+
+    fun deleteUser(): User {
+        state = StateType.DELETED
+        return this
+    }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/domain/User.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/domain/User.kt
@@ -7,6 +7,7 @@ import java.time.LocalDate
 
 @Entity
 @Table(
+    name = "`user`",
     uniqueConstraints = [UniqueConstraint(
         name = "PROVIDER_OID_UNIQUE",
         columnNames = ["provider", "oid"]

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/domain/User.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/domain/User.kt
@@ -1,6 +1,7 @@
 package com.example.enterparkticket.core.domain.user.domain
 
 import com.example.enterparkticket.core.domain.common.BaseTimeEntity
+import com.example.enterparkticket.core.domain.user.exception.ReRegisterUserException
 import jakarta.persistence.*
 import java.time.LocalDate
 
@@ -54,5 +55,16 @@ class User(
         this.email = email
         this.phoneNumber = phoneNumber
         this.address = address
+    }
+
+    fun withdrawUser() {
+        state = StateType.SUSPENDED
+        deleteSoftly()
+    }
+
+    fun validateState() {
+        if (state == StateType.SUSPENDED) {
+            throw ReRegisterUserException()
+        }
     }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/DeleteKakaoTokenException.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/DeleteKakaoTokenException.kt
@@ -1,0 +1,6 @@
+package com.example.enterparkticket.core.domain.user.exception
+
+import com.example.enterparkticket.core.domain.common.exeption.EnterparkTicketException
+
+class DeleteKakaoTokenException : EnterparkTicketException(UserErrorCode.KAKAO_TOKEN_DELETED) {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/ReRegisterUserException.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/ReRegisterUserException.kt
@@ -1,0 +1,6 @@
+package com.example.enterparkticket.core.domain.user.exception
+
+import com.example.enterparkticket.core.domain.common.exeption.EnterparkTicketException
+
+class ReRegisterUserException : EnterparkTicketException(UserErrorCode.USER_RE_REGISTER) {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/UserErrorCode.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/UserErrorCode.kt
@@ -2,6 +2,7 @@ package com.example.enterparkticket.core.domain.user.exception
 
 import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.CONFLICT
 import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.NOT_FOUND
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.UNAUTHORIZED
 import com.example.enterparkticket.core.domain.common.exeption.BaseErrorCode
 import com.example.enterparkticket.core.domain.common.exeption.ErrorDescription
 
@@ -9,7 +10,8 @@ enum class UserErrorCode(private val status: Int, private val message: String) :
 
     USER_ALREADY_REGISTER(CONFLICT, "이미 존재하는 회원입니다."),
     USER_NOT_FOUND(NOT_FOUND, "존재하지 않는 회원입니다."),
-    KAKAO_TOKEN_NOT_FOUND(NOT_FOUND, "해당 회원의 카카오 토큰이 존재하지 않습니다.");
+    KAKAO_TOKEN_NOT_FOUND(NOT_FOUND, "해당 회원의 카카오 토큰이 존재하지 않습니다."),
+    USER_RE_REGISTER(UNAUTHORIZED, "탈퇴 후 7일 이내에는 재가입이 불가능합니다.");
 
     override fun getErrorDescription(): ErrorDescription {
         return ErrorDescription(name, message, status)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/UserErrorCode.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/exception/UserErrorCode.kt
@@ -1,6 +1,7 @@
 package com.example.enterparkticket.core.domain.user.exception
 
 import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.CONFLICT
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.INTERNAL_SERVER_ERROR
 import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.NOT_FOUND
 import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.UNAUTHORIZED
 import com.example.enterparkticket.core.domain.common.exeption.BaseErrorCode
@@ -11,7 +12,8 @@ enum class UserErrorCode(private val status: Int, private val message: String) :
     USER_ALREADY_REGISTER(CONFLICT, "이미 존재하는 회원입니다."),
     USER_NOT_FOUND(NOT_FOUND, "존재하지 않는 회원입니다."),
     KAKAO_TOKEN_NOT_FOUND(NOT_FOUND, "해당 회원의 카카오 토큰이 존재하지 않습니다."),
-    USER_RE_REGISTER(UNAUTHORIZED, "탈퇴 후 7일 이내에는 재가입이 불가능합니다.");
+    USER_RE_REGISTER(UNAUTHORIZED, "탈퇴 후 7일 이내에는 재가입이 불가능합니다."),
+    KAKAO_TOKEN_DELETED(INTERNAL_SERVER_ERROR, "카카오 토큰 삭제가 실패하였습니다.");
 
     override fun getErrorDescription(): ErrorDescription {
         return ErrorDescription(name, message, status)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/repository/UserRepository.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/repository/UserRepository.kt
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<User, Long> {
 
-    fun existsByOAuthInfo(oAuthInfo: OAuthInfo): Boolean
+    fun findByOAuthInfo(oAuthInfo: OAuthInfo): User?
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/KakaoTokenService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/KakaoTokenService.kt
@@ -1,6 +1,7 @@
 package com.example.enterparkticket.core.domain.user.service
 
 import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.KAKAO_TOKEN_PREFIX
+import com.example.enterparkticket.core.domain.user.exception.DeleteKakaoTokenException
 import com.example.enterparkticket.core.domain.user.exception.NotFoundKakaoTokenException
 import com.example.enterparkticket.core.domain.user.service.dto.KakaoTokenDto
 import org.springframework.data.redis.core.RedisTemplate
@@ -23,6 +24,13 @@ class KakaoTokenService(private val redisTemplate: RedisTemplate<String, String>
             value
         } else {
             throw NotFoundKakaoTokenException()
+        }
+    }
+
+    fun deleteToken(oAuthId: Long) {
+        val key = KAKAO_TOKEN_PREFIX + oAuthId
+        if (!redisTemplate.delete(key)) {
+            throw DeleteKakaoTokenException()
         }
     }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/KakaoTokenService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/KakaoTokenService.kt
@@ -29,8 +29,11 @@ class KakaoTokenService(private val redisTemplate: RedisTemplate<String, String>
 
     fun deleteToken(oAuthId: Long) {
         val key = KAKAO_TOKEN_PREFIX + oAuthId
-        if (!redisTemplate.delete(key)) {
-            throw DeleteKakaoTokenException()
+        if (redisTemplate.hasKey(key)) {
+            val isDeleted = redisTemplate.delete(key)
+            if (!isDeleted) {
+                throw DeleteKakaoTokenException()
+            }
         }
     }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/UserDomainService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/UserDomainService.kt
@@ -34,8 +34,16 @@ class UserDomainService(private val userRepository: UserRepository) {
         }
     }
 
+    @Transactional
+    fun withdrawUser(userId: Long): User {
+        val user = findUserById(userId)
+        user.withdrawUser()
+        return user
+    }
+
     private fun validateUser(oAuthInfo: OAuthInfo) {
-        if (userRepository.existsByOAuthInfo(oAuthInfo)) {
+        userRepository.findByOAuthInfo(oAuthInfo)?.let {
+            it.validateState()
             throw AlreadyRegisterUserException()
         }
     }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/UserDomainService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/UserDomainService.kt
@@ -1,5 +1,6 @@
 package com.example.enterparkticket.core.domain.user.service
 
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.BATCH_TRANSACTION_MANAGER
 import com.example.enterparkticket.core.domain.user.domain.OAuthInfo
 import com.example.enterparkticket.core.domain.user.domain.User
 import com.example.enterparkticket.core.domain.user.exception.AlreadyRegisterUserException
@@ -39,6 +40,11 @@ class UserDomainService(private val userRepository: UserRepository) {
         val user = findUserById(userId)
         user.withdrawUser()
         return user
+    }
+
+    @Transactional(BATCH_TRANSACTION_MANAGER)
+    fun deleteUser(user: User): User {
+        return user.deleteUser()
     }
 
     private fun validateUser(oAuthInfo: OAuthInfo) {

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/UserDomainService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/user/service/UserDomainService.kt
@@ -1,6 +1,7 @@
 package com.example.enterparkticket.core.domain.user.service
 
 import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.BATCH_TRANSACTION_MANAGER
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.PRIMARY_TRANSACTION_MANAGER
 import com.example.enterparkticket.core.domain.user.domain.OAuthInfo
 import com.example.enterparkticket.core.domain.user.domain.User
 import com.example.enterparkticket.core.domain.user.exception.AlreadyRegisterUserException
@@ -15,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class UserDomainService(private val userRepository: UserRepository) {
 
-    @Transactional
+    @Transactional(PRIMARY_TRANSACTION_MANAGER)
     fun registerUser(oAuthInfo: OAuthInfo, email: String, dto: RegisterUserDto): User {
         validateUser(oAuthInfo)
         val user = dto.toUserEntity(oAuthInfo, email)
@@ -23,7 +24,7 @@ class UserDomainService(private val userRepository: UserRepository) {
         return user
     }
 
-    @Transactional
+    @Transactional(PRIMARY_TRANSACTION_MANAGER)
     fun updateUser(userId: Long, dto: UpdateUserDto) {
         val user = findUserById(userId)
         user.updateUser(dto.name, dto.email, dto.phoneNumber, dto.address)
@@ -35,7 +36,7 @@ class UserDomainService(private val userRepository: UserRepository) {
         }
     }
 
-    @Transactional
+    @Transactional(PRIMARY_TRANSACTION_MANAGER)
     fun withdrawUser(userId: Long): User {
         val user = findUserById(userId)
         user.withdrawUser()

--- a/enterpark-ticket-core/domain/src/main/resources/application-domain.yml
+++ b/enterpark-ticket-core/domain/src/main/resources/application-domain.yml
@@ -3,10 +3,16 @@ spring:
     activate:
       on-profile: local
   datasource:
-    url: jdbc:mysql://localhost:3307/${LOCAL_MYSQL_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
-    username: ${LOCAL_MYSQL_USERNAME}
-    password: ${LOCAL_MYSQL_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    primary:
+      jdbc-url: jdbc:mysql://localhost:3307/${LOCAL_MYSQL_NAME}?useSSL=false&characterEncoding=UTF-8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+      username: ${LOCAL_MYSQL_USERNAME}
+      password: ${LOCAL_MYSQL_PASSWORD}
+      driver-class-name: com.mysql.cj.jdbc.Driver
+    batch:
+      jdbc-url: jdbc:mysql://localhost:3308/${BATCH_MYSQL_NAME}?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+      username: ${BATCH_MYSQL_USERNAME}
+      password: ${BATCH_MYSQL_PASSWORD}
+      driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
## 📌 개요
- close #7 

## 💾 작업사항
- 카카오 연결 끊기 API 요청 → 서비스 탈퇴 처리
  - 서비스가 갑자기 중지되거나, 사용자가 사용하지 못하는 경우가 있을 수 있기 때문에, 액세스 토큰보다 adminKey로 unlink를 호출하였습니다.
- 7일 이내 재가입 불가
  - 탈퇴한 회원 상태를 SUSPENDED(정지) 상태로 변경하고, 탈퇴 날짜 저장
  - 재가입시 이를 확인하여 SUSPENDED인 경우 가입 차단
- 스프링 배치를 이용하여, 7일 이후 SUSPENDED(정지) → DELETED(탈퇴)로 상태 변경
- 배치 메타 테이블 DB와 domain 엔티티 DB 분리

## 🌠 기타
JpaConfig에서 dataSource, transactionManager, entityManagerFactory 빈 등록시
```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'transactionManager' defined in class path resource [org/springframework/boot/autoconfigure/orm/jpa/HibernateJpaConfiguration.class]: No qualifying bean of type 'jakarta.persistence.EntityManagerFactory' available: more than one 'primary' bean found among candidates: [entityManagerFactory, primaryEntityManagerFactory]
```
이런 에러가 나서 HibernateJpaConfiguration에 대해 찾아보니, `@ConditionalOnMissingBean`을 통해 동일한 이름의 빈이 존재하지 않는 경우에만 빈을 등록하는 것을 알게되었습니다.
그런데 `@Qualifier`로 명확히 지정하고, 빈의 이름도 다른 이름을 사용했는데, 왜 HibernateJpaConfiguration에서는 빈을 못 정하는지 궁금합니다.

그래서 service 클래스에서 `@Transactional(PRIMARY_TRANSACTION_MANAGER)` 이런식으로 명확히 지정해주니 잘 동작하긴 했습니다ㅜㅠ