### PR TITLE
[feat] 티켓 예매

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,8 +49,9 @@ subprojects {
         testImplementation("io.kotest:kotest-property:5.8.1")
         testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
         testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:2.0.2")
-        testImplementation("org.testcontainers:testcontainers:1.20.4")
-        testImplementation("org.testcontainers:junit-jupiter:1.20.4")
+        testImplementation("org.testcontainers:testcontainers")
+        testImplementation("org.testcontainers:junit-jupiter")
+        testImplementation("org.testcontainers:mysql")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,16 @@ subprojects {
     dependencies {
         implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         implementation("org.jetbrains.kotlin:kotlin-reflect")
+        implementation("io.github.oshai:kotlin-logging-jvm:7.0.0")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+        testImplementation("io.kotest:kotest-runner-junit5:5.8.1")
+        testImplementation("io.kotest:kotest-assertions-core:5.8.1")
+        testImplementation("io.kotest:kotest-property:5.8.1")
+        testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
+        testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:2.0.2")
+        testImplementation("org.testcontainers:testcontainers:1.20.4")
+        testImplementation("org.testcontainers:junit-jupiter:1.20.4")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     }
 }

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/SecurityConfig.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/SecurityConfig.kt
@@ -3,6 +3,7 @@ package com.example.enterparkticket.apis.enduser.config
 import com.example.enterparkticket.apis.enduser.config.jwt.JwtTokenFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -11,6 +12,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 class SecurityConfig(private val jwtTokenFilter: JwtTokenFilter) {
 
     @Bean

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/exception/GlobalExceptionHandler.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/exception/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.example.enterparkticket.apis.enduser.config.exception
 import com.example.enterparkticket.apis.enduser.config.exception.dto.ErrorResponse
 import com.example.enterparkticket.core.domain.common.exeption.EnterparkTicketException
 import com.example.enterparkticket.core.domain.common.exeption.GlobalErrorCode.SERVER_ERROR
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.ConstraintViolationException
 import org.springframework.http.HttpHeaders
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+private val kLogger = KotlinLogging.logger {}
 
 @RestControllerAdvice
 class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
@@ -82,6 +85,7 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
         ex: Exception,
         request: HttpServletRequest
     ): ResponseEntity<ErrorResponse> {
+        kLogger.error { ex.message }
         val errorDescription = SERVER_ERROR.getErrorDescription()
         val response = ErrorResponse(errorDescription.code, errorDescription.message)
         return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(response)

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/log/MDCLoggingFilter.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/config/log/MDCLoggingFilter.kt
@@ -1,0 +1,31 @@
+package com.example.enterparkticket.apis.enduser.config.log
+
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import org.slf4j.MDC
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class MDCLoggingFilter : Filter {
+
+    override fun doFilter(
+        request: ServletRequest,
+        response: ServletResponse,
+        filterChain: FilterChain
+    ) {
+        val uuid = UUID.randomUUID()
+        MDC.put(REQUEST_ID, uuid.toString())
+        filterChain.doFilter(request, response)
+        MDC.clear()
+    }
+
+    companion object {
+        const val REQUEST_ID = "request_id"
+    }
+}

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/reservation/controller/ReservationController.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/reservation/controller/ReservationController.kt
@@ -1,0 +1,33 @@
+package com.example.enterparkticket.apis.enduser.reservation.controller
+
+import com.example.enterparkticket.apis.enduser.config.jwt.dto.AuthDetails
+import com.example.enterparkticket.apis.enduser.config.jwt.dto.AuthUser
+import com.example.enterparkticket.apis.enduser.config.jwt.dto.toUserId
+import com.example.enterparkticket.apis.enduser.reservation.dto.request.CreateReservationRequest
+import com.example.enterparkticket.core.domain.reservation.service.ReservationDomainService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Validated
+@RestController
+@RequestMapping("/v1/reservations")
+class ReservationController(private val reservationDomainService: ReservationDomainService) {
+
+    @PostMapping
+    fun createReservation(
+        @AuthUser user: AuthDetails,
+        @Valid @RequestBody request: CreateReservationRequest,
+    ): ResponseEntity<String> {
+        reservationDomainService.createReservation(
+            user.toUserId(),
+            request.toCreateReservationDto()
+        )
+        return ResponseEntity.status(CREATED).body("예매가 완료되었습니다.")
+    }
+}

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/reservation/controller/ReservationController.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/reservation/controller/ReservationController.kt
@@ -4,7 +4,7 @@ import com.example.enterparkticket.apis.enduser.config.jwt.dto.AuthDetails
 import com.example.enterparkticket.apis.enduser.config.jwt.dto.AuthUser
 import com.example.enterparkticket.apis.enduser.config.jwt.dto.toUserId
 import com.example.enterparkticket.apis.enduser.reservation.dto.request.CreateReservationRequest
-import com.example.enterparkticket.core.domain.reservation.service.ReservationDomainService
+import com.example.enterparkticket.apis.enduser.reservation.service.CreateUseCase
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.ResponseEntity
@@ -17,17 +17,14 @@ import org.springframework.web.bind.annotation.RestController
 @Validated
 @RestController
 @RequestMapping("/v1/reservations")
-class ReservationController(private val reservationDomainService: ReservationDomainService) {
+class ReservationController(private val createUseCase: CreateUseCase) {
 
     @PostMapping
     fun createReservation(
         @AuthUser user: AuthDetails,
         @Valid @RequestBody request: CreateReservationRequest,
     ): ResponseEntity<String> {
-        reservationDomainService.createReservation(
-            user.toUserId(),
-            request.toCreateReservationDto()
-        )
+        createUseCase.createReservation(user.toUserId(), request)
         return ResponseEntity.status(CREATED).body("예매가 완료되었습니다.")
     }
 }

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/reservation/dto/request/CreateReservationRequest.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/reservation/dto/request/CreateReservationRequest.kt
@@ -1,0 +1,37 @@
+package com.example.enterparkticket.apis.enduser.reservation.dto.request
+
+import com.example.enterparkticket.core.domain.reservation.domain.TicketReceiptType
+import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationDto
+import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationSeatDto
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+
+data class CreateReservationRequest(
+
+    @field:NotNull(message = "공연 아이디는 필수 입력입니다.")
+    val performanceId: Long,
+
+    @field:NotNull(message = "티켓 수령 방법은 필수 입력입니다.")
+    val ticketReceiptType: TicketReceiptType,
+
+    @field:Size(min = 1, max = 10, message = "좌석은 1~10개만 가능합니다.")
+    @field:Valid
+    val seats: List<CreateReservationSeatRequest>,
+) {
+
+    fun toCreateReservationDto(): CreateReservationDto {
+        return CreateReservationDto(
+            performanceId,
+            ticketReceiptType,
+            seats.map { CreateReservationSeatDto(it.seatNumber) }
+        )
+    }
+}
+
+data class CreateReservationSeatRequest(
+
+    @field:NotBlank(message = "좌석 번호는 필수 입력입니다.")
+    val seatNumber: String,
+)

--- a/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/reservation/service/CreateUseCase.kt
+++ b/enterpark-ticket-apis/enduser/src/main/kotlin/com/example/enterparkticket/apis/enduser/reservation/service/CreateUseCase.kt
@@ -1,0 +1,24 @@
+package com.example.enterparkticket.apis.enduser.reservation.service
+
+import com.example.enterparkticket.apis.enduser.reservation.dto.request.CreateReservationRequest
+import com.example.enterparkticket.core.domain.performance.service.PerformanceDomainService
+import com.example.enterparkticket.core.domain.reservation.service.ReservationDomainService
+import com.example.enterparkticket.core.domain.user.service.UserDomainService
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Service
+
+@Service
+class CreateUseCase(
+    private val userDomainService: UserDomainService,
+    private val performanceDomainService: PerformanceDomainService,
+    private val reservationDomainService: ReservationDomainService,
+) {
+
+    @PreAuthorize("hasRole('USER')")
+    fun createReservation(userId: Long, request: CreateReservationRequest) {
+        val user = userDomainService.findUserById(userId)
+        val performance = performanceDomainService.findPerformanceById(request.performanceId)
+        performance.validateUserAge(user.birthDate)
+        reservationDomainService.createReservation(userId, request.toCreateReservationDto())
+    }
+}

--- a/enterpark-ticket-apis/enduser/src/main/resources/logback-spring.xml
+++ b/enterpark-ticket-apis/enduser/src/main/resources/logback-spring.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <property name="DATE_PATTERN" value="yyyy-MM-dd"/>
+  <property name="LOG_PATTERN"
+    value="[%X{request_id:-startup}] [%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOG_PATH}/${DATE_PATTERN}.log</file>
+    <encoder>
+      <pattern>${LOG_PATTERN}</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${LOG_PATH}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>3GB</totalSizeCap>
+      <maxFileSize>100MB</maxFileSize>
+    </rollingPolicy>
+  </appender>
+
+  <springProfile name="local">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+
+  <springProfile name="dev">
+    <property name="LOG_PATH" value="./logs/dev"/>
+
+    <root level="INFO">
+      <appender-ref ref="FILE"/>
+    </root>
+  </springProfile>
+
+  <springProfile name="prod">
+    <property name="LOG_PATH" value="./logs/prod"/>
+
+    <root level="INFO">
+      <appender-ref ref="FILE"/>
+    </root>
+  </springProfile>
+
+</configuration>

--- a/enterpark-ticket-core/domain/build.gradle.kts
+++ b/enterpark-ticket-core/domain/build.gradle.kts
@@ -9,6 +9,7 @@ jar.enabled = true
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.redisson:redisson-spring-boot-starter:3.40.0")
 
     implementation("org.flywaydb:flyway-mysql")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/aop/Async.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/aop/Async.kt
@@ -1,0 +1,29 @@
+package com.example.enterparkticket.core.domain.common.aop
+
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+
+@Component
+class Async(advice: AsyncAdvice) {
+
+    init {
+        asyncAdvice = advice
+    }
+
+    companion object {
+        private lateinit var asyncAdvice: AsyncAdvice
+
+        fun <T> eventTaskExecutor(function: () -> T): T {
+            return asyncAdvice.eventTaskExecutor(function)
+        }
+    }
+
+    @Component
+    class AsyncAdvice {
+
+        @Async("eventTaskExecutor")
+        fun <T> eventTaskExecutor(function: () -> T): T {
+            return function.invoke()
+        }
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/aop/DistributedLock.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/aop/DistributedLock.kt
@@ -1,0 +1,51 @@
+package com.example.enterparkticket.core.domain.common.aop
+
+import com.example.enterparkticket.core.domain.common.aop.DistributedLock.Companion.LEASE_TIME
+import com.example.enterparkticket.core.domain.common.aop.DistributedLock.Companion.WAIT_TIME
+import com.example.enterparkticket.core.domain.common.aop.DistributedLock.Companion.createKey
+import com.example.enterparkticket.core.domain.common.aop.DistributedLock.Companion.redissonClient
+import com.example.enterparkticket.core.domain.common.exeption.NotAvailableDistributedLockException
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+private val logger = KotlinLogging.logger {}
+
+fun <T> lock(vararg keys: String, function: () -> T): T {
+    val rLock = redissonClient.getLock(createKey(keys))
+    try {
+        val available = rLock.tryLock(WAIT_TIME, LEASE_TIME, TimeUnit.SECONDS)
+        if (!available) {
+            throw NotAvailableDistributedLockException()
+        }
+        logger.info { "redisson lock 실행 ${createKey(keys)} 스레드 ${Thread.currentThread().id}" }
+        return Transaction.propagationRequiresNew(function)
+    } catch (e: InterruptedException) {
+        throw e
+    } finally {
+        try {
+            rLock.unlock()
+        } catch (e: IllegalMonitorStateException) {
+            throw e
+        }
+    }
+}
+
+@Component
+class DistributedLock(client: RedissonClient) {
+
+    init {
+        redissonClient = client
+    }
+
+    companion object {
+        lateinit var redissonClient: RedissonClient
+            private set
+        private const val SEPARATOR = ":"
+        const val WAIT_TIME = 5L
+        const val LEASE_TIME = 3L
+
+        fun createKey(keys: Array<out Any>) = keys.joinToString(SEPARATOR)
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/aop/Transaction.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/aop/Transaction.kt
@@ -1,0 +1,31 @@
+package com.example.enterparkticket.core.domain.common.aop
+
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.PRIMARY_TRANSACTION_MANAGER
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class Transaction(advice: TransactionAdvice) {
+
+    init {
+        transactionAdvice = advice
+    }
+
+    companion object {
+        private lateinit var transactionAdvice: TransactionAdvice
+
+        fun <T> propagationRequiresNew(function: () -> T): T {
+            return transactionAdvice.propagationRequiresNew(function)
+        }
+    }
+
+    @Component
+    class TransactionAdvice {
+
+        @Transactional(value = PRIMARY_TRANSACTION_MANAGER, propagation = Propagation.REQUIRES_NEW)
+        fun <T> propagationRequiresNew(function: () -> T): T {
+            return function.invoke()
+        }
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/exeption/GlobalErrorCode.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/exeption/GlobalErrorCode.kt
@@ -9,7 +9,8 @@ enum class GlobalErrorCode(private val status: Int, private val message: String)
     EXPIRED_TOKEN(UNAUTHORIZED, "만료된 토큰입니다."),
     INVALID_EMAIL(UNAUTHORIZED, "유효하지 않은 이메일 주소입니다."),
 
-    SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버 오류가 발생하였습니다.");
+    SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버 오류가 발생하였습니다."),
+    NOT_AVAILABLE_DISTRIBUTED_LOCK(INTERNAL_SERVER_ERROR, "DistributedLock is not available");
 
     override fun getErrorDescription(): ErrorDescription {
         return ErrorDescription(name, message, status)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/exeption/GlobalErrorCode.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/exeption/GlobalErrorCode.kt
@@ -10,7 +10,7 @@ enum class GlobalErrorCode(private val status: Int, private val message: String)
     INVALID_EMAIL(UNAUTHORIZED, "유효하지 않은 이메일 주소입니다."),
 
     SERVER_ERROR(INTERNAL_SERVER_ERROR, "서버 오류가 발생하였습니다."),
-    NOT_AVAILABLE_DISTRIBUTED_LOCK(INTERNAL_SERVER_ERROR, "DistributedLock is not available");
+    NOT_AVAILABLE_DISTRIBUTED_LOCK(INTERNAL_SERVER_ERROR, "락 획득에 실패하였습니다.");
 
     override fun getErrorDescription(): ErrorDescription {
         return ErrorDescription(name, message, status)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/exeption/NotAvailableDistributedLockException.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/common/exeption/NotAvailableDistributedLockException.kt
@@ -1,0 +1,5 @@
+package com.example.enterparkticket.core.domain.common.exeption
+
+class NotAvailableDistributedLockException :
+    EnterparkTicketException(GlobalErrorCode.NOT_AVAILABLE_DISTRIBUTED_LOCK) {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/EnterparkTicketConfigGroup.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/EnterparkTicketConfigGroup.kt
@@ -1,9 +1,11 @@
 package com.example.enterparkticket.core.domain.config
 
+import com.example.enterparkticket.core.domain.config.async.AsyncConfig
 import com.example.enterparkticket.core.domain.config.jpa.JpaConfig
 import com.example.enterparkticket.core.domain.config.redis.RedisConfig
 
 enum class EnterparkTicketConfigGroup(val configClass: Class<out EnterparkTicketConfig>) {
     JPA(JpaConfig::class.java),
     REDIS(RedisConfig::class.java),
+    ASYNC(AsyncConfig::class.java),
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/InfraConfig.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/InfraConfig.kt
@@ -2,8 +2,9 @@ package com.example.enterparkticket.core.domain.config
 
 import com.example.enterparkticket.core.domain.config.EnterparkTicketConfigGroup.*
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 
+@Profile("!test")
 @Configuration
 @EnableEnterparkTicketConfig([JPA, REDIS])
-class InfraConfig {
-}
+class InfraConfig

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/InfraConfig.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/InfraConfig.kt
@@ -6,5 +6,5 @@ import org.springframework.context.annotation.Profile
 
 @Profile("!test")
 @Configuration
-@EnableEnterparkTicketConfig([JPA, REDIS])
+@EnableEnterparkTicketConfig([JPA, REDIS, ASYNC])
 class InfraConfig

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/async/AsyncConfig.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/async/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package com.example.enterparkticket.core.domain.config.async
+
+import com.example.enterparkticket.core.domain.config.EnterparkTicketConfig
+import org.springframework.scheduling.annotation.EnableAsync
+
+@EnableAsync
+class AsyncConfig : EnterparkTicketConfig {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/async/AsyncConfig.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/async/AsyncConfig.kt
@@ -1,8 +1,23 @@
 package com.example.enterparkticket.core.domain.config.async
 
 import com.example.enterparkticket.core.domain.config.EnterparkTicketConfig
+import org.springframework.context.annotation.Bean
 import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.ThreadPoolExecutor
 
 @EnableAsync
 class AsyncConfig : EnterparkTicketConfig {
+
+    @Bean
+    fun eventTaskExecutor(): ThreadPoolTaskExecutor {
+        return ThreadPoolTaskExecutor().apply {
+            corePoolSize = 10
+            queueCapacity = 50
+            maxPoolSize = 30
+            setThreadNamePrefix("event-async-")
+            setTaskDecorator(LoggingTaskDecorator())
+            setRejectedExecutionHandler(ThreadPoolExecutor.CallerRunsPolicy())
+        }
+    }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/async/LoggingTaskDecorator.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/async/LoggingTaskDecorator.kt
@@ -1,0 +1,18 @@
+package com.example.enterparkticket.core.domain.config.async
+
+import org.slf4j.MDC
+import org.springframework.core.task.TaskDecorator
+
+class LoggingTaskDecorator : TaskDecorator {
+
+    override fun decorate(task: Runnable): Runnable {
+        val callerThreadContext = MDC.getCopyOfContextMap()
+
+        return Runnable {
+            callerThreadContext?.let {
+                MDC.setContextMap(it)
+            }
+            task.run()
+        }
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/redis/RedisConfig.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/config/redis/RedisConfig.kt
@@ -1,9 +1,13 @@
 package com.example.enterparkticket.core.domain.config.redis
 
 import com.example.enterparkticket.core.domain.config.EnterparkTicketConfig
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.domain.EntityScan
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.RedisPassword
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
@@ -24,6 +28,7 @@ class RedisConfig(
 ) : EnterparkTicketConfig {
 
     @Bean
+    @Primary
     fun customRedisConnectionFactory(): RedisConnectionFactory {
         val config = RedisStandaloneConfiguration(host, port).apply {
             password = RedisPassword.of(this@RedisConfig.password)
@@ -38,5 +43,20 @@ class RedisConfig(
             keySerializer = StringRedisSerializer()
             valueSerializer = StringRedisSerializer()
         }
+    }
+
+    @Bean
+    @Primary
+    fun redissonClient(): RedissonClient {
+        val config = Config().apply {
+            useSingleServer()
+                .setAddress("$REDISSON_HOST_PREFIX$host:$port")
+                .setPassword(password)
+        }
+        return Redisson.create(config)
+    }
+
+    companion object {
+        const val REDISSON_HOST_PREFIX = "redis://"
     }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/payment/event/ReservationWaitingPaymentEventHandler.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/payment/event/ReservationWaitingPaymentEventHandler.kt
@@ -1,0 +1,20 @@
+package com.example.enterparkticket.core.domain.payment.event
+
+import com.example.enterparkticket.core.domain.common.aop.Transaction
+import com.example.enterparkticket.core.domain.reservation.event.ReservationWaitingPaymentEvent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionalEventListener
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class ReservationWaitingPaymentEventHandler {
+
+    @Async
+    @TransactionalEventListener
+    fun handle(event: ReservationWaitingPaymentEvent) = Transaction.propagationRequiresNew {
+        logger.info { "티켓 예매 결제 하기 ${event.reservationIds}" }
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/payment/event/ReservationWaitingPaymentEventHandler.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/payment/event/ReservationWaitingPaymentEventHandler.kt
@@ -1,9 +1,9 @@
 package com.example.enterparkticket.core.domain.payment.event
 
+import com.example.enterparkticket.core.domain.common.aop.Async
 import com.example.enterparkticket.core.domain.common.aop.Transaction
 import com.example.enterparkticket.core.domain.reservation.event.ReservationWaitingPaymentEvent
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionalEventListener
 
@@ -12,9 +12,10 @@ private val logger = KotlinLogging.logger {}
 @Component
 class ReservationWaitingPaymentEventHandler {
 
-    @Async
     @TransactionalEventListener
-    fun handle(event: ReservationWaitingPaymentEvent) = Transaction.propagationRequiresNew {
-        logger.info { "티켓 예매 결제 하기 ${event.reservationIds}" }
+    fun handle(event: ReservationWaitingPaymentEvent) = Async.eventTaskExecutor {
+        Transaction.propagationRequiresNew {
+            logger.info { "티켓 예매 결제 하기 ${event.reservationIds}" }
+        }
     }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/AgeLimitType.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/AgeLimitType.kt
@@ -1,8 +1,8 @@
 package com.example.enterparkticket.core.domain.performance.domain
 
-enum class AgeLimitType(val value: String) {
-    ALL("전체 관람가"),
-    AGE_12("12세 이상"),
-    AGE_15("15세 이상"),
-    AGE_19("19세 이상"),
+enum class AgeLimitType(val value: String, val age: Int) {
+    ALL("전체 관람가", 0),
+    AGE_12("12세 이상", 12),
+    AGE_15("15세 이상", 15),
+    AGE_19("19세 이상", 19),
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/AgeLimitType.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/AgeLimitType.kt
@@ -1,0 +1,8 @@
+package com.example.enterparkticket.core.domain.performance.domain
+
+enum class AgeLimitType(val value: String) {
+    ALL("전체 관람가"),
+    AGE_12("12세 이상"),
+    AGE_15("15세 이상"),
+    AGE_19("19세 이상"),
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Casting.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Casting.kt
@@ -1,0 +1,26 @@
+package com.example.enterparkticket.core.domain.performance.domain
+
+import com.example.enterparkticket.core.domain.common.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class Casting(
+
+    @Column(nullable = false, length = 15)
+    var name: String,
+
+    @Column(nullable = false, length = 20)
+    var role: String,
+
+    @Column(nullable = true, length = 255)
+    var imageUrl: String? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    var schedule: Schedule? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "casting_id")
+    var id: Long? = null,
+) : BaseEntity()

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Performance.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Performance.kt
@@ -1,6 +1,7 @@
 package com.example.enterparkticket.core.domain.performance.domain
 
 import com.example.enterparkticket.core.domain.common.BaseEntity
+import com.example.enterparkticket.core.domain.performance.exception.AgeLimitException
 import jakarta.persistence.*
 import java.time.LocalDate
 
@@ -36,4 +37,13 @@ class Performance(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "performance_id")
     var id: Long? = null,
-) : BaseEntity()
+) : BaseEntity() {
+
+    fun validateUserAge(birthDate: LocalDate) {
+        val currentDate = LocalDate.now()
+        val userAge = currentDate.year - birthDate.year + 1
+        if (userAge < ageLimit.age) {
+            throw AgeLimitException()
+        }
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Performance.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Performance.kt
@@ -1,0 +1,39 @@
+package com.example.enterparkticket.core.domain.performance.domain
+
+import com.example.enterparkticket.core.domain.common.BaseEntity
+import jakarta.persistence.*
+import java.time.LocalDate
+
+@Entity
+class Performance(
+
+    @Column(nullable = false, length = 255)
+    var title: String,
+
+    @Column(nullable = false, length = 255)
+    var imageUrl: String,
+
+    @Column(nullable = false, length = 255)
+    var description: String,
+
+    @Column(nullable = false)
+    var startDate: LocalDate,
+
+    @Column(nullable = false)
+    var endDate: LocalDate,
+
+    @Column(nullable = false)
+    var totalTime: Int,
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false, length = 15)
+    var ageLimit: AgeLimitType,
+
+    @Column(nullable = false)
+    var placeId: Long,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "performance_id")
+    var id: Long? = null,
+) : BaseEntity()

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Performance.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Performance.kt
@@ -41,9 +41,13 @@ class Performance(
 
     fun validateUserAge(birthDate: LocalDate) {
         val currentDate = LocalDate.now()
-        val userAge = currentDate.year - birthDate.year + 1
+        val userAge = currentDate.year - birthDate.year + AGE_OFFSET
         if (userAge < ageLimit.age) {
             throw AgeLimitException()
         }
+    }
+
+    companion object {
+        const val AGE_OFFSET = 1
     }
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Schedule.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/domain/Schedule.kt
@@ -1,0 +1,24 @@
+package com.example.enterparkticket.core.domain.performance.domain
+
+import com.example.enterparkticket.core.domain.common.BaseEntity
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+class Schedule(
+
+    @Column(nullable = false)
+    var dateTime: LocalDateTime,
+
+    @Column(nullable = false)
+    var sequence: Int,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id")
+    var performance: Performance? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "schedule_id")
+    var id: Long? = null,
+) : BaseEntity()

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/exception/AgeLimitException.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/exception/AgeLimitException.kt
@@ -1,0 +1,6 @@
+package com.example.enterparkticket.core.domain.performance.exception
+
+import com.example.enterparkticket.core.domain.common.exeption.EnterparkTicketException
+
+class AgeLimitException : EnterparkTicketException(PerformanceErrorCode.AGE_LIMIT) {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/exception/NotFoundPerformanceException.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/exception/NotFoundPerformanceException.kt
@@ -1,0 +1,7 @@
+package com.example.enterparkticket.core.domain.performance.exception
+
+import com.example.enterparkticket.core.domain.common.exeption.EnterparkTicketException
+
+class NotFoundPerformanceException :
+    EnterparkTicketException(PerformanceErrorCode.PERFORMANCE_NOT_FOUND) {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/exception/PerformanceErrorCode.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/exception/PerformanceErrorCode.kt
@@ -1,0 +1,17 @@
+package com.example.enterparkticket.core.domain.performance.exception
+
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.BAD_REQUEST
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.NOT_FOUND
+import com.example.enterparkticket.core.domain.common.exeption.BaseErrorCode
+import com.example.enterparkticket.core.domain.common.exeption.ErrorDescription
+
+enum class PerformanceErrorCode(private val status: Int, private val message: String) :
+    BaseErrorCode {
+
+    PERFORMANCE_NOT_FOUND(NOT_FOUND, "존재하지 않는 공연입니다."),
+    AGE_LIMIT(BAD_REQUEST, "공연 관람 가능 나이가 아닙니다.");
+
+    override fun getErrorDescription(): ErrorDescription {
+        return ErrorDescription(name, message, status)
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/repository/PerformanceRepository.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/repository/PerformanceRepository.kt
@@ -1,0 +1,7 @@
+package com.example.enterparkticket.core.domain.performance.repository
+
+import com.example.enterparkticket.core.domain.performance.domain.Performance
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PerformanceRepository : JpaRepository<Performance, Long> {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/service/PerformanceDomainService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/performance/service/PerformanceDomainService.kt
@@ -1,0 +1,20 @@
+package com.example.enterparkticket.core.domain.performance.service
+
+import com.example.enterparkticket.core.domain.performance.domain.Performance
+import com.example.enterparkticket.core.domain.performance.exception.NotFoundPerformanceException
+import com.example.enterparkticket.core.domain.performance.repository.PerformanceRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class PerformanceDomainService(
+    private val performanceRepository: PerformanceRepository,
+) {
+
+    fun findPerformanceById(performanceId: Long): Performance {
+        return performanceRepository.findById(performanceId).orElseThrow {
+            NotFoundPerformanceException()
+        }
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/place/domain/Place.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/place/domain/Place.kt
@@ -1,4 +1,4 @@
-package com.example.enterparkticket.core.domain.seat.domain
+package com.example.enterparkticket.core.domain.place.domain
 
 import com.example.enterparkticket.core.domain.common.BaseEntity
 import jakarta.persistence.*

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/place/repository/PlaceRepository.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/place/repository/PlaceRepository.kt
@@ -1,0 +1,7 @@
+package com.example.enterparkticket.core.domain.place.repository
+
+import com.example.enterparkticket.core.domain.place.domain.Place
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PlaceRepository : JpaRepository<Place, Long> {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/domain/Reservation.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/domain/Reservation.kt
@@ -1,0 +1,32 @@
+package com.example.enterparkticket.core.domain.reservation.domain
+
+import com.example.enterparkticket.core.domain.common.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class Reservation(
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false, length = 15)
+    var state: StateType,
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false, length = 15)
+    var ticketReceipt: TicketReceiptType,
+
+    @Column(nullable = false)
+    var userId: Long,
+
+    @Column(nullable = false)
+    var performanceId: Long,
+
+    @Column(nullable = false)
+    var seatId: Long?,
+
+    // todo 결제 정보
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id")
+    var id: Long? = null,
+) : BaseEntity()

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/domain/Reservation.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/domain/Reservation.kt
@@ -4,6 +4,12 @@ import com.example.enterparkticket.core.domain.common.BaseEntity
 import jakarta.persistence.*
 
 @Entity
+@Table(
+    indexes = [Index(
+        name = "idx_user_id_performance_id",
+        columnList = "user_id, performance_id",
+    )]
+)
 class Reservation(
 
     @Enumerated(value = EnumType.STRING)
@@ -22,8 +28,6 @@ class Reservation(
 
     @Column(nullable = false)
     var seatId: Long?,
-
-    // todo 결제 정보
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/domain/StateType.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/domain/StateType.kt
@@ -1,0 +1,7 @@
+package com.example.enterparkticket.core.domain.reservation.domain
+
+enum class StateType(val value: String) {
+    WAITING_PAYMENT("결제 대기"),
+    RESERVED("예매 완료"),
+    CANCELED("예매 취소"),
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/domain/TicketReceiptType.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/domain/TicketReceiptType.kt
@@ -1,0 +1,6 @@
+package com.example.enterparkticket.core.domain.reservation.domain
+
+enum class TicketReceiptType(val value: String) {
+    ON_SITE("현장 수령"),
+    DELIVERY("배송"),
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/event/ReservationWaitingPaymentEvent.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/event/ReservationWaitingPaymentEvent.kt
@@ -1,0 +1,5 @@
+package com.example.enterparkticket.core.domain.reservation.event
+
+data class ReservationWaitingPaymentEvent(
+    val reservationIds: List<Long?>,
+)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/repository/ReservationRepository.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/repository/ReservationRepository.kt
@@ -1,0 +1,7 @@
+package com.example.enterparkticket.core.domain.reservation.repository
+
+import com.example.enterparkticket.core.domain.reservation.domain.Reservation
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReservationRepository : JpaRepository<Reservation, Long> {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationDomainService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationDomainService.kt
@@ -1,30 +1,39 @@
 package com.example.enterparkticket.core.domain.reservation.service
 
 import com.example.enterparkticket.core.domain.common.aop.lock
+import com.example.enterparkticket.core.domain.performance.service.PerformanceDomainService
 import com.example.enterparkticket.core.domain.reservation.event.ReservationWaitingPaymentEvent
 import com.example.enterparkticket.core.domain.reservation.repository.ReservationRepository
 import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationDto
 import com.example.enterparkticket.core.domain.seat.repository.SeatRepository
+import com.example.enterparkticket.core.domain.user.service.UserDomainService
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
 class ReservationDomainService(
+    private val userDomainService: UserDomainService,
+    private val performanceDomainService: PerformanceDomainService,
     private val seatRepository: SeatRepository,
     private val reservationRepository: ReservationRepository,
     private val publisher: ApplicationEventPublisher,
 ) {
 
     fun createReservation(userId: Long, dto: CreateReservationDto) {
-        lock(SEAT_LOCK_KEY, "${dto.performanceId}", "${dto.seats}") {
+        val user = userDomainService.findUserById(userId)
+        val performanceId = dto.performanceId
+        val performance = performanceDomainService.findPerformanceById(performanceId)
+        performance.validateUserAge(user.birthDate)
+
+        lock(SEAT_LOCK_KEY, "$performanceId", "${dto.seats}") {
             val seatNumbers = dto.seats.map { it.seatNumber }
             val seats = seatRepository
-                .findByGradeSeatPerformanceIdAndSeatNumberIn(dto.performanceId, seatNumbers)
+                .findByGradeSeatPerformanceIdAndSeatNumberIn(performanceId, seatNumbers)
                 .onEach {
                     it.validateIsReserved()
                 }
 
-            seatRepository.bulkUpdateReserveSeats(dto.performanceId, seatNumbers)
+            seatRepository.bulkUpdateReserveSeats(performanceId, seatNumbers)
 
             val reservations = seats.map { dto.toReservationEntity(userId, it.id) }
             val reservationIds = reservations.map { it.id }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationDomainService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationDomainService.kt
@@ -16,7 +16,7 @@ class ReservationDomainService(
         lock(SEAT_LOCK_KEY, "${dto.performanceId}", "${dto.seats}") {
             val seatNumbers = dto.seats.map { it.seatNumber }
             val seats = seatRepository
-                .findByPerformanceIdAndSeatNumberIn(dto.performanceId, seatNumbers)
+                .findByGradeSeatPerformanceIdAndSeatNumberIn(dto.performanceId, seatNumbers)
                 .onEach {
                     it.validateIsReserved()
                 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationDomainService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationDomainService.kt
@@ -1,0 +1,34 @@
+package com.example.enterparkticket.core.domain.reservation.service
+
+import com.example.enterparkticket.core.domain.common.aop.lock
+import com.example.enterparkticket.core.domain.reservation.repository.ReservationRepository
+import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationDto
+import com.example.enterparkticket.core.domain.seat.repository.SeatRepository
+import org.springframework.stereotype.Service
+
+@Service
+class ReservationDomainService(
+    private val seatRepository: SeatRepository,
+    private val reservationRepository: ReservationRepository,
+) {
+
+    fun createReservation(userId: Long, dto: CreateReservationDto) {
+        lock(SEAT_LOCK_KEY, "${dto.performanceId}", "${dto.seats}") {
+            val seatNumbers = dto.seats.map { it.seatNumber }
+            val seats = seatRepository
+                .findByPerformanceIdAndSeatNumberIn(dto.performanceId, seatNumbers)
+                .onEach {
+                    it.validateIsReserved()
+                }
+
+            seatRepository.bulkUpdateReserveSeats(dto.performanceId, seatNumbers)
+
+            val reservations = seats.map { dto.toReservationEntity(userId, it.id) }
+            reservationRepository.saveAll(reservations)
+        }
+    }
+
+    companion object {
+        const val SEAT_LOCK_KEY = "SEAT_LOCK"
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationDomainService.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationDomainService.kt
@@ -1,30 +1,22 @@
 package com.example.enterparkticket.core.domain.reservation.service
 
 import com.example.enterparkticket.core.domain.common.aop.lock
-import com.example.enterparkticket.core.domain.performance.service.PerformanceDomainService
 import com.example.enterparkticket.core.domain.reservation.event.ReservationWaitingPaymentEvent
 import com.example.enterparkticket.core.domain.reservation.repository.ReservationRepository
 import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationDto
 import com.example.enterparkticket.core.domain.seat.repository.SeatRepository
-import com.example.enterparkticket.core.domain.user.service.UserDomainService
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 
 @Service
 class ReservationDomainService(
-    private val userDomainService: UserDomainService,
-    private val performanceDomainService: PerformanceDomainService,
     private val seatRepository: SeatRepository,
     private val reservationRepository: ReservationRepository,
     private val publisher: ApplicationEventPublisher,
 ) {
 
     fun createReservation(userId: Long, dto: CreateReservationDto) {
-        val user = userDomainService.findUserById(userId)
         val performanceId = dto.performanceId
-        val performance = performanceDomainService.findPerformanceById(performanceId)
-        performance.validateUserAge(user.birthDate)
-
         lock(SEAT_LOCK_KEY, "$performanceId", "${dto.seats}") {
             val seatNumbers = dto.seats.map { it.seatNumber }
             val seats = seatRepository

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/dto/CreateReservationDto.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/reservation/service/dto/CreateReservationDto.kt
@@ -1,0 +1,26 @@
+package com.example.enterparkticket.core.domain.reservation.service.dto
+
+import com.example.enterparkticket.core.domain.reservation.domain.Reservation
+import com.example.enterparkticket.core.domain.reservation.domain.StateType
+import com.example.enterparkticket.core.domain.reservation.domain.TicketReceiptType
+
+data class CreateReservationDto(
+    val performanceId: Long,
+    val ticketReceiptType: TicketReceiptType,
+    val seats: List<CreateReservationSeatDto>,
+) {
+
+    fun toReservationEntity(userId: Long, seatId: Long?): Reservation {
+        return Reservation(
+            StateType.WAITING_PAYMENT,
+            ticketReceiptType,
+            userId,
+            performanceId,
+            seatId,
+        )
+    }
+}
+
+data class CreateReservationSeatDto(
+    val seatNumber: String,
+)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/GradeSeat.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/GradeSeat.kt
@@ -5,6 +5,7 @@ import com.example.enterparkticket.core.domain.performance.domain.Performance
 import jakarta.persistence.*
 
 @Entity
+@Table(indexes = [Index(name = "idx_performance_id", columnList = "performance_id")])
 class GradeSeat(
 
     @Enumerated(value = EnumType.STRING)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/GradeSeat.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/GradeSeat.kt
@@ -1,0 +1,28 @@
+package com.example.enterparkticket.core.domain.seat.domain
+
+import com.example.enterparkticket.core.domain.common.BaseEntity
+import com.example.enterparkticket.core.domain.performance.domain.Performance
+import jakarta.persistence.*
+
+@Entity
+class GradeSeat(
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = false, length = 15)
+    var grade: GradeType,
+
+    @Column(nullable = false)
+    var seatCount: Int,
+
+    @Column(nullable = false)
+    var price: Int,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "performance_id")
+    var performance: Performance? = null,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "grade_seat_id")
+    var id: Long? = null,
+) : BaseEntity()

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/GradeType.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/GradeType.kt
@@ -1,0 +1,9 @@
+package com.example.enterparkticket.core.domain.seat.domain
+
+enum class GradeType {
+    VIP,
+    R,
+    S,
+    A,
+    B,
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/GradeType.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/GradeType.kt
@@ -1,9 +1,9 @@
 package com.example.enterparkticket.core.domain.seat.domain
 
-enum class GradeType {
-    VIP,
-    R,
-    S,
-    A,
-    B,
+enum class GradeType(val value: String) {
+    VIP("VIP석"),
+    R("R석"),
+    S("S석"),
+    A("A석"),
+    B("B석"),
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Place.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Place.kt
@@ -1,0 +1,19 @@
+package com.example.enterparkticket.core.domain.seat.domain
+
+import com.example.enterparkticket.core.domain.common.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+class Place(
+
+    @Column(nullable = false, length = 255)
+    var name: String,
+
+    @Column(nullable = false, length = 255)
+    var address: String,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "place_id")
+    var id: Long? = null,
+) : BaseEntity()

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
@@ -7,8 +7,9 @@ import jakarta.persistence.*
 @Entity
 class Seat(
 
+    @Enumerated(value = EnumType.STRING)
     @Column(nullable = false, length = 15)
-    var grade: String,
+    var grade: GradeType,
 
     @Column(nullable = false, length = 15)
     var seatNumber: String,

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
@@ -6,9 +6,9 @@ import jakarta.persistence.*
 
 @Entity
 @Table(
-    indexes = [Index(
-        name = "idx_grade_seat_id_seat_number",
-        columnList = "grade_seat_id, seat_number",
+    uniqueConstraints = [UniqueConstraint(
+        name = "unique_grade_seat_id_seat_number",
+        columnNames = ["grade_seat_id", "seat_number"],
     )]
 )
 class Seat(

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
@@ -7,22 +7,12 @@ import jakarta.persistence.*
 @Entity
 class Seat(
 
-    @Enumerated(value = EnumType.STRING)
-    @Column(nullable = false, length = 15)
-    var grade: GradeType,
-
     @Column(nullable = false, length = 15)
     var seatNumber: String,
 
-    @Column(nullable = false)
-    var price: Int,
-
-    @Column(nullable = false)
-    var performanceId: Long,
-
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "place_id")
-    var place: Place? = null,
+    @JoinColumn(name = "grade_seat_id")
+    var gradeSeat: GradeSeat? = null,
 
     @Column(nullable = false)
     var isReserved: Boolean = false,

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
@@ -5,6 +5,12 @@ import com.example.enterparkticket.core.domain.seat.exception.AlreadyReservedSea
 import jakarta.persistence.*
 
 @Entity
+@Table(
+    indexes = [Index(
+        name = "idx_grade_seat_id_seat_number",
+        columnList = "grade_seat_id, seat_number",
+    )]
+)
 class Seat(
 
     @Column(nullable = false, length = 15)

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/domain/Seat.kt
@@ -1,0 +1,40 @@
+package com.example.enterparkticket.core.domain.seat.domain
+
+import com.example.enterparkticket.core.domain.common.BaseEntity
+import com.example.enterparkticket.core.domain.seat.exception.AlreadyReservedSeatException
+import jakarta.persistence.*
+
+@Entity
+class Seat(
+
+    @Column(nullable = false, length = 15)
+    var grade: String,
+
+    @Column(nullable = false, length = 15)
+    var seatNumber: String,
+
+    @Column(nullable = false)
+    var price: Int,
+
+    @Column(nullable = false)
+    var performanceId: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id")
+    var place: Place? = null,
+
+    @Column(nullable = false)
+    var isReserved: Boolean = false,
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "seat_id")
+    var id: Long? = null,
+) : BaseEntity() {
+
+    fun validateIsReserved() {
+        if (isReserved) {
+            throw AlreadyReservedSeatException()
+        }
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/exception/AlreadyReservedSeatException.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/exception/AlreadyReservedSeatException.kt
@@ -1,0 +1,7 @@
+package com.example.enterparkticket.core.domain.seat.exception
+
+import com.example.enterparkticket.core.domain.common.exeption.EnterparkTicketException
+
+class AlreadyReservedSeatException :
+    EnterparkTicketException(ReservationErrorCode.SEAT_ALREADY_RESERVED) {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/exception/ReservationErrorCode.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/exception/ReservationErrorCode.kt
@@ -1,0 +1,17 @@
+package com.example.enterparkticket.core.domain.seat.exception
+
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.CONFLICT
+import com.example.enterparkticket.core.domain.common.exeption.BaseErrorCode
+import com.example.enterparkticket.core.domain.common.exeption.ErrorDescription
+
+enum class ReservationErrorCode(
+    private val status: Int,
+    private val message: String
+) : BaseErrorCode {
+
+    SEAT_ALREADY_RESERVED(CONFLICT, "이미 예매된 좌석입니다.");
+
+    override fun getErrorDescription(): ErrorDescription {
+        return ErrorDescription(name, message, status)
+    }
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/GradeSeatRepository.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/GradeSeatRepository.kt
@@ -1,0 +1,7 @@
+package com.example.enterparkticket.core.domain.seat.repository
+
+import com.example.enterparkticket.core.domain.seat.domain.GradeSeat
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GradeSeatRepository : JpaRepository<GradeSeat, Long> {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/PlaceRepository.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/PlaceRepository.kt
@@ -1,0 +1,7 @@
+package com.example.enterparkticket.core.domain.seat.repository
+
+import com.example.enterparkticket.core.domain.seat.domain.Place
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PlaceRepository : JpaRepository<Place, Long> {
+}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/PlaceRepository.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/PlaceRepository.kt
@@ -1,7 +1,0 @@
-package com.example.enterparkticket.core.domain.seat.repository
-
-import com.example.enterparkticket.core.domain.seat.domain.Place
-import org.springframework.data.jpa.repository.JpaRepository
-
-interface PlaceRepository : JpaRepository<Place, Long> {
-}

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/SeatRepository.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/SeatRepository.kt
@@ -7,12 +7,12 @@ import org.springframework.data.jpa.repository.Query
 
 interface SeatRepository : JpaRepository<Seat, Long> {
 
-    fun findByPerformanceIdAndSeatNumberIn(
+    fun findByGradeSeatPerformanceIdAndSeatNumberIn(
         performanceId: Long,
         seatNumbers: List<String>
     ): List<Seat>
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Seat s SET s.isReserved = true WHERE s.performanceId = :performanceId AND s.seatNumber IN :seatNumbers")
+    @Query("UPDATE Seat s SET s.isReserved = true WHERE s.gradeSeat.performance.id = :performanceId AND s.seatNumber IN :seatNumbers")
     fun bulkUpdateReserveSeats(performanceId: Long, seatNumbers: List<String>)
 }

--- a/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/SeatRepository.kt
+++ b/enterpark-ticket-core/domain/src/main/kotlin/com/example/enterparkticket/core/domain/seat/repository/SeatRepository.kt
@@ -1,0 +1,18 @@
+package com.example.enterparkticket.core.domain.seat.repository
+
+import com.example.enterparkticket.core.domain.seat.domain.Seat
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+
+interface SeatRepository : JpaRepository<Seat, Long> {
+
+    fun findByPerformanceIdAndSeatNumberIn(
+        performanceId: Long,
+        seatNumbers: List<String>
+    ): List<Seat>
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Seat s SET s.isReserved = true WHERE s.performanceId = :performanceId AND s.seatNumber IN :seatNumbers")
+    fun bulkUpdateReserveSeats(performanceId: Long, seatNumbers: List<String>)
+}

--- a/enterpark-ticket-core/domain/src/main/resources/application-domain.yml
+++ b/enterpark-ticket-core/domain/src/main/resources/application-domain.yml
@@ -28,7 +28,7 @@ spring:
     redis:
       host: localhost
       port: 6379
-      password:
+      password: ${REDIS_PASSWORD}
 logging:
   level:
     org.hibernate.SQL: debug

--- a/enterpark-ticket-core/domain/src/main/resources/db/migration/V1.3__create_other_table.sql
+++ b/enterpark-ticket-core/domain/src/main/resources/db/migration/V1.3__create_other_table.sql
@@ -1,0 +1,85 @@
+CREATE TABLE IF NOT EXISTS performance
+(
+    performance_id     BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '공연 id',
+    title              VARCHAR(255) NOT NULL COMMENT '제목',
+    image_url          VARCHAR(255) NOT NULL COMMENT '이미지',
+    description        VARCHAR(255) NOT NULL COMMENT '설명',
+    start_date         DATE         NOT NULL COMMENT '시작 날짜',
+    end_date           DATE         NOT NULL COMMENT '종료 날짜',
+    total_time         INT          NOT NULL COMMENT '총 시간',
+    age_limit          VARCHAR(15)  NOT NULL COMMENT '관람연령',
+    place_id           BIGINT       NOT NULL COMMENT '장소 id',
+    created_date       TIMESTAMP(6) NULL COMMENT '생성일',
+    last_modified_date TIMESTAMP(6) NULL COMMENT '수정일',
+    deleted_date       TIMESTAMP(6) NULL COMMENT '삭제일',
+    created_by         VARCHAR(255) NULL COMMENT '생성자',
+    last_modified_by   VARCHAR(255) NULL COMMENT '수정자'
+);
+CREATE TABLE IF NOT EXISTS schedule
+(
+    schedule_id        BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '스케줄 id',
+    date_time          TIMESTAMP(6) NOT NULL COMMENT '날짜',
+    sequence           INT          NOT NULL COMMENT '회차',
+    performance_id     BIGINT       NOT NULL COMMENT '공연 id',
+    created_date       TIMESTAMP(6) NULL COMMENT '생성일',
+    last_modified_date TIMESTAMP(6) NULL COMMENT '수정일',
+    deleted_date       TIMESTAMP(6) NULL COMMENT '삭제일',
+    created_by         VARCHAR(255) NULL COMMENT '생성자',
+    last_modified_by   VARCHAR(255) NULL COMMENT '수정자',
+    CONSTRAINT fk_performance_schedule FOREIGN KEY (performance_id) REFERENCES performance (performance_id)
+);
+CREATE TABLE IF NOT EXISTS casting
+(
+    casting_id         BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '캐스팅 id',
+    name               VARCHAR(15)  NOT NULL COMMENT '이름',
+    role               VARCHAR(20)  NOT NULL COMMENT '역할',
+    image_url          VARCHAR(255) NULL COMMENT '이미지',
+    schedule_id        BIGINT       NOT NULL COMMENT '스케줄 id',
+    created_date       TIMESTAMP(6) NULL COMMENT '생성일',
+    last_modified_date TIMESTAMP(6) NULL COMMENT '수정일',
+    deleted_date       TIMESTAMP(6) NULL COMMENT '삭제일',
+    created_by         VARCHAR(255) NULL COMMENT '생성자',
+    last_modified_by   VARCHAR(255) NULL COMMENT '수정자',
+    CONSTRAINT fk_schedule_casting FOREIGN KEY (schedule_id) REFERENCES schedule (schedule_id)
+);
+CREATE TABLE IF NOT EXISTS place
+(
+    place_id           BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '장소 id',
+    name               VARCHAR(255) NOT NULL COMMENT '공연장 이름',
+    address            VARCHAR(255) NOT NULL COMMENT '주소',
+    created_date       TIMESTAMP(6) NULL COMMENT '생성일',
+    last_modified_date TIMESTAMP(6) NULL COMMENT '수정일',
+    deleted_date       TIMESTAMP(6) NULL COMMENT '삭제일',
+    created_by         VARCHAR(255) NULL COMMENT '생성자',
+    last_modified_by   VARCHAR(255) NULL COMMENT '수정자'
+);
+CREATE TABLE IF NOT EXISTS seat
+(
+    seat_id            BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '좌석 id',
+    grade              VARCHAR(15)  NOT NULL COMMENT '등급',
+    seat_number        VARCHAR(15)  NOT NULL COMMENT '좌석 번호',
+    price              INT          NOT NULL COMMENT '가격',
+    performance_id     BIGINT       NOT NULL COMMENT '공연 id',
+    is_reserved        BOOLEAN      NOT NULL COMMENT '예매 여부',
+    place_id           BIGINT       NOT NULL COMMENT '장소 id',
+    created_date       TIMESTAMP(6) NULL COMMENT '생성일',
+    last_modified_date TIMESTAMP(6) NULL COMMENT '수정일',
+    deleted_date       TIMESTAMP(6) NULL COMMENT '삭제일',
+    created_by         VARCHAR(255) NULL COMMENT '생성자',
+    last_modified_by   VARCHAR(255) NULL COMMENT '수정자',
+    CONSTRAINT fk_place_seat FOREIGN KEY (place_id) REFERENCES place (place_id)
+);
+CREATE TABLE IF NOT EXISTS reservation
+(
+    reservation_id     BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '예매 id',
+    state              VARCHAR(15)  NOT NULL COMMENT '상태',
+    ticket_receipt     VARCHAR(15)  NOT NULL COMMENT '티켓 수령 방법',
+    user_id            BIGINT       NOT NULL COMMENT '회원 id',
+    performance_id     BIGINT       NOT NULL COMMENT '공연 id',
+    seat_id            BIGINT       NOT NULL COMMENT '좌석 id',
+    created_date       TIMESTAMP(6) NULL COMMENT '생성일',
+    last_modified_date TIMESTAMP(6) NULL COMMENT '수정일',
+    deleted_date       TIMESTAMP(6) NULL COMMENT '삭제일',
+    created_by         VARCHAR(255) NULL COMMENT '생성자',
+    last_modified_by   VARCHAR(255) NULL COMMENT '수정자'
+);

--- a/enterpark-ticket-core/domain/src/main/resources/db/migration/V1.3__create_other_table.sql
+++ b/enterpark-ticket-core/domain/src/main/resources/db/migration/V1.3__create_other_table.sql
@@ -53,21 +53,33 @@ CREATE TABLE IF NOT EXISTS place
     created_by         VARCHAR(255) NULL COMMENT '생성자',
     last_modified_by   VARCHAR(255) NULL COMMENT '수정자'
 );
-CREATE TABLE IF NOT EXISTS seat
+CREATE TABLE grade_seat
 (
-    seat_id            BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '좌석 id',
+    grade_seat_id      BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '좌석 등급 id',
     grade              VARCHAR(15)  NOT NULL COMMENT '등급',
-    seat_number        VARCHAR(15)  NOT NULL COMMENT '좌석 번호',
+    seat_count         INT          NOT NULL COMMENT '좌석 수',
     price              INT          NOT NULL COMMENT '가격',
     performance_id     BIGINT       NOT NULL COMMENT '공연 id',
-    is_reserved        BOOLEAN      NOT NULL COMMENT '예매 여부',
-    place_id           BIGINT       NOT NULL COMMENT '장소 id',
     created_date       TIMESTAMP(6) NULL COMMENT '생성일',
     last_modified_date TIMESTAMP(6) NULL COMMENT '수정일',
     deleted_date       TIMESTAMP(6) NULL COMMENT '삭제일',
     created_by         VARCHAR(255) NULL COMMENT '생성자',
     last_modified_by   VARCHAR(255) NULL COMMENT '수정자',
-    CONSTRAINT fk_place_seat FOREIGN KEY (place_id) REFERENCES place (place_id)
+    INDEX idx_performance_id (performance_id)
+);
+CREATE TABLE IF NOT EXISTS seat
+(
+    seat_id            BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '좌석 id',
+    seat_number        VARCHAR(15)  NOT NULL COMMENT '좌석 번호',
+    grade_seat_id      BIGINT       NOT NULL COMMENT '좌석 등급 id',
+    is_reserved        BOOLEAN      NOT NULL COMMENT '예매 여부',
+    created_date       TIMESTAMP(6) NULL COMMENT '생성일',
+    last_modified_date TIMESTAMP(6) NULL COMMENT '수정일',
+    deleted_date       TIMESTAMP(6) NULL COMMENT '삭제일',
+    created_by         VARCHAR(255) NULL COMMENT '생성자',
+    last_modified_by   VARCHAR(255) NULL COMMENT '수정자',
+    CONSTRAINT fk_grade_seat_seat FOREIGN KEY (grade_seat_id) REFERENCES grade_seat (grade_seat_id),
+    UNIQUE unique_grade_seat_id_seat_number (grade_seat_id, seat_number)
 );
 CREATE TABLE IF NOT EXISTS reservation
 (
@@ -81,5 +93,6 @@ CREATE TABLE IF NOT EXISTS reservation
     last_modified_date TIMESTAMP(6) NULL COMMENT '수정일',
     deleted_date       TIMESTAMP(6) NULL COMMENT '삭제일',
     created_by         VARCHAR(255) NULL COMMENT '생성자',
-    last_modified_by   VARCHAR(255) NULL COMMENT '수정자'
+    last_modified_by   VARCHAR(255) NULL COMMENT '수정자',
+    INDEX idx_user_id_performance_id (user_id, performance_id)
 );

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/DomainSpringBootApplication.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/DomainSpringBootApplication.kt
@@ -1,0 +1,6 @@
+package com.example.enterparkticket.core.domain
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+class DomainSpringBootApplication

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/performance/domain/PerformanceTest.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/performance/domain/PerformanceTest.kt
@@ -1,0 +1,96 @@
+package com.example.enterparkticket.core.domain.performance.domain
+
+import com.example.enterparkticket.core.domain.performance.exception.AgeLimitException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import java.time.LocalDate
+
+class PerformanceTest : FunSpec({
+
+    context("validateUserAge") {
+        val birthDateAll = LocalDate.now()
+        val birthDate12 = LocalDate.of(birthDateAll.year - 12, 1, 1)
+        val birthDate15 = LocalDate.of(birthDateAll.year - 15, 1, 1)
+        val birthDate19 = LocalDate.of(birthDateAll.year - 19, 1, 1)
+
+        test("공연 나이 제한이 전체 관람가일 경우 모든 회원이 예매 가능") {
+            val performance = Performance(
+                "알라딘",
+                "이미지",
+                "설명",
+                LocalDate.of(2024, 12, 19),
+                LocalDate.of(2025, 1, 19),
+                120,
+                AgeLimitType.ALL,
+                1L
+            )
+            performance.validateUserAge(birthDateAll)
+            performance.validateUserAge(birthDate12)
+            performance.validateUserAge(birthDate15)
+            performance.validateUserAge(birthDate19)
+        }
+
+        test("공연 나이 제한이 12세 이상일 경우 12세 이상인 회원만 예매 가능") {
+            val performance = Performance(
+                "알라딘",
+                "이미지",
+                "설명",
+                LocalDate.of(2024, 12, 19),
+                LocalDate.of(2025, 1, 19),
+                120,
+                AgeLimitType.AGE_12,
+                1L
+            )
+            shouldThrow<AgeLimitException> {
+                performance.validateUserAge(birthDateAll)
+            }
+            performance.validateUserAge(birthDate12)
+            performance.validateUserAge(birthDate15)
+            performance.validateUserAge(birthDate19)
+        }
+
+        test("공연 나이 제한이 15세 이상일 경우 15세 이상인 회원만 예매 가능") {
+            val performance = Performance(
+                "알라딘",
+                "이미지",
+                "설명",
+                LocalDate.of(2024, 12, 19),
+                LocalDate.of(2025, 1, 19),
+                120,
+                AgeLimitType.AGE_15,
+                1L
+            )
+            shouldThrow<AgeLimitException> {
+                performance.validateUserAge(birthDateAll)
+            }
+            shouldThrow<AgeLimitException> {
+                performance.validateUserAge(birthDate12)
+            }
+            performance.validateUserAge(birthDate15)
+            performance.validateUserAge(birthDate19)
+        }
+
+        test("공연 나이 제한이 19세 이상일 경우 19세 이상인 회원만 예매 가능") {
+            val performance = Performance(
+                "알라딘",
+                "이미지",
+                "설명",
+                LocalDate.of(2024, 12, 19),
+                LocalDate.of(2025, 1, 19),
+                120,
+                AgeLimitType.AGE_19,
+                1L
+            )
+            shouldThrow<AgeLimitException> {
+                performance.validateUserAge(birthDateAll)
+            }
+            shouldThrow<AgeLimitException> {
+                performance.validateUserAge(birthDate12)
+            }
+            shouldThrow<AgeLimitException> {
+                performance.validateUserAge(birthDate15)
+            }
+            performance.validateUserAge(birthDate19)
+        }
+    }
+})

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/config/DomainSpringBootTest.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/config/DomainSpringBootTest.kt
@@ -1,0 +1,14 @@
+package com.example.enterparkticket.core.domain.reservation.config
+
+import com.example.enterparkticket.core.domain.DomainSpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@SpringBootTest(
+    classes = [DomainSpringBootApplication::class],
+    properties = ["spring.profiles.active=test"],
+)
+@ContextConfiguration(classes = [JpaTestConfig::class])
+annotation class DomainSpringBootTest

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/config/JpaTestConfig.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/config/JpaTestConfig.kt
@@ -1,0 +1,69 @@
+package com.example.enterparkticket.core.domain.reservation.config
+
+import com.example.enterparkticket.core.domain.common.consts.EnterparkTicketConsts.PRIMARY_TRANSACTION_MANAGER
+import com.example.enterparkticket.core.domain.config.jpa.JpaConfig.Companion.PRIMARY_ENTITY_MANAGER_FACTORY
+import jakarta.persistence.EntityManagerFactory
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateSettings
+import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.jdbc.DataSourceBuilder
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.orm.jpa.JpaTransactionManager
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.EnableTransactionManagement
+import javax.sql.DataSource
+
+@EnableTransactionManagement
+@EntityScan(basePackages = ["com.example.enterparkticket"])
+@EnableJpaRepositories(
+    basePackages = ["com.example.enterparkticket"],
+    entityManagerFactoryRef = PRIMARY_ENTITY_MANAGER_FACTORY,
+    transactionManagerRef = PRIMARY_TRANSACTION_MANAGER,
+)
+class JpaTestConfig(
+    private val jpaProperties: JpaProperties,
+    private val hibernateProperties: HibernateProperties,
+) {
+
+    @Bean
+    @ConfigurationProperties(prefix = PRIMARY_CONFIGURATION_PROPERTIES_PREFIX)
+    fun primaryDataSource(): DataSource {
+        return DataSourceBuilder.create().build()
+    }
+
+    @Bean
+    fun primaryEntityManagerFactory(
+        builder: EntityManagerFactoryBuilder,
+        @Qualifier(PRIMARY_DATASOURCE) dataSource: DataSource,
+    ): LocalContainerEntityManagerFactoryBean {
+        val properties = hibernateProperties.determineHibernateProperties(
+            jpaProperties.properties,
+            HibernateSettings()
+        )
+        return builder.dataSource(dataSource)
+            .packages("com.example.enterparkticket")
+            .persistenceUnit(PRIMARY_PERSISTENCE_UNIT)
+            .properties(properties)
+            .build()
+    }
+
+    @Bean
+    fun primaryTransactionManager(
+        @Qualifier(PRIMARY_ENTITY_MANAGER_FACTORY) entityManagerFactory: EntityManagerFactory,
+    ): PlatformTransactionManager {
+        return JpaTransactionManager(entityManagerFactory)
+    }
+
+    companion object {
+        const val PRIMARY_CONFIGURATION_PROPERTIES_PREFIX = "spring.datasource.primary"
+        const val PRIMARY_PERSISTENCE_UNIT = "primaryPersistenceUnit"
+        const val PRIMARY_DATASOURCE = "primaryDataSource"
+        const val PRIMARY_ENTITY_MANAGER_FACTORY = "primaryEntityManagerFactory"
+    }
+}

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/config/JpaTestConfig.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/config/JpaTestConfig.kt
@@ -32,7 +32,7 @@ class JpaTestConfig(
 ) {
 
     @Bean
-    @ConfigurationProperties(prefix = PRIMARY_CONFIGURATION_PROPERTIES_PREFIX)
+    @ConfigurationProperties(prefix = TEST_CONFIGURATION_PROPERTIES_PREFIX)
     fun primaryDataSource(): DataSource {
         return DataSourceBuilder.create().build()
     }
@@ -61,7 +61,7 @@ class JpaTestConfig(
     }
 
     companion object {
-        const val PRIMARY_CONFIGURATION_PROPERTIES_PREFIX = "spring.datasource.primary"
+        const val TEST_CONFIGURATION_PROPERTIES_PREFIX = "spring.datasource.test"
         const val PRIMARY_PERSISTENCE_UNIT = "primaryPersistenceUnit"
         const val PRIMARY_DATASOURCE = "primaryDataSource"
         const val PRIMARY_ENTITY_MANAGER_FACTORY = "primaryEntityManagerFactory"

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/config/RedisExtension.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/config/RedisExtension.kt
@@ -1,0 +1,19 @@
+package com.example.enterparkticket.core.domain.reservation.config
+
+import io.kotest.core.extensions.MountableExtension
+import org.testcontainers.containers.GenericContainer
+
+class RedisExtension : MountableExtension<Unit, GenericContainer<*>> {
+
+    override fun mount(configure: Unit.() -> Unit): GenericContainer<*> {
+        return GenericContainer(IMAGE_NAME).apply {
+            startupAttempts = 1
+            withExposedPorts(REDIS_PORT)
+        }
+    }
+
+    companion object {
+        const val REDIS_PORT = 6379
+        const val IMAGE_NAME = "redis:latest"
+    }
+}

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
@@ -22,6 +22,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.testcontainers.perSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationEventPublisher
 import java.time.LocalDate
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
@@ -37,6 +38,7 @@ class ReservationConcurrencyTest @Autowired constructor(
     private val gradeSeatRepository: GradeSeatRepository,
     private val seatRepository: SeatRepository,
     private val reservationRepository: ReservationRepository,
+    private val publisher: ApplicationEventPublisher,
 ) : BehaviorSpec({
 
     val redis = install(RedisExtension())
@@ -50,7 +52,8 @@ class ReservationConcurrencyTest @Autowired constructor(
     beforeTest {
         executorService = Executors.newFixedThreadPool(nThreads)
         countDownLatch = CountDownLatch(nThreads)
-        reservationDomainService = ReservationDomainService(seatRepository, reservationRepository)
+        reservationDomainService =
+            ReservationDomainService(seatRepository, reservationRepository, publisher)
     }
 
     Given("동시성 티켓 예매") {

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
@@ -1,0 +1,79 @@
+package com.example.enterparkticket.core.domain.reservation.service
+
+import com.example.enterparkticket.core.domain.reservation.config.DomainSpringBootTest
+import com.example.enterparkticket.core.domain.reservation.config.RedisExtension
+import com.example.enterparkticket.core.domain.reservation.domain.TicketReceiptType
+import com.example.enterparkticket.core.domain.reservation.repository.ReservationRepository
+import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationDto
+import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationSeatDto
+import com.example.enterparkticket.core.domain.seat.domain.Place
+import com.example.enterparkticket.core.domain.seat.domain.Seat
+import com.example.enterparkticket.core.domain.seat.repository.PlaceRepository
+import com.example.enterparkticket.core.domain.seat.repository.SeatRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.core.extensions.install
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.testcontainers.perSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+private val logger = KotlinLogging.logger {}
+
+@DomainSpringBootTest
+class ReservationConcurrencyTest @Autowired constructor(
+    private val placeRepository: PlaceRepository,
+    private val seatRepository: SeatRepository,
+    private val reservationRepository: ReservationRepository,
+) : BehaviorSpec({
+
+    val redis = install(RedisExtension())
+    listeners(redis.perSpec())
+
+    val nThreads = 1000
+    lateinit var executorService: ExecutorService
+    lateinit var countDownLatch: CountDownLatch
+    lateinit var reservationDomainService: ReservationDomainService
+
+    beforeTest {
+        executorService = Executors.newFixedThreadPool(nThreads)
+        countDownLatch = CountDownLatch(nThreads)
+        reservationDomainService = ReservationDomainService(seatRepository, reservationRepository)
+    }
+
+    Given("동시성 티켓 예매") {
+        val place = Place("고척스카이돔", "서울특별시 구로구 경인로 430")
+        placeRepository.save(place)
+        val seats = listOf("A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1", "I1", "J1", "K1").map {
+            Seat("S", it, 100000, 100L, place)
+        }
+        seatRepository.saveAll(seats)
+
+        When("1000개의 요청이 동시에 실행되면") {
+            val userId = 1L
+            val successCounter = AtomicInteger()
+            val seatsDto = listOf(CreateReservationSeatDto("A1"), CreateReservationSeatDto("K1"))
+            val dto = CreateReservationDto(100L, TicketReceiptType.DELIVERY, seatsDto)
+            repeat(nThreads) {
+                executorService.submit {
+                    try {
+                        reservationDomainService.createReservation(userId, dto)
+                        successCounter.getAndIncrement()
+                    } catch (e: Exception) {
+                        logger.error { e.message }
+                    } finally {
+                        countDownLatch.countDown()
+                    }
+                }
+            }
+            countDownLatch.await()
+
+            Then("1개의 요청만 성공해야 한다") {
+                successCounter.get() shouldBe 1
+            }
+        }
+    }
+})

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
@@ -6,6 +6,7 @@ import com.example.enterparkticket.core.domain.reservation.domain.TicketReceiptT
 import com.example.enterparkticket.core.domain.reservation.repository.ReservationRepository
 import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationDto
 import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationSeatDto
+import com.example.enterparkticket.core.domain.seat.domain.GradeType
 import com.example.enterparkticket.core.domain.seat.domain.Place
 import com.example.enterparkticket.core.domain.seat.domain.Seat
 import com.example.enterparkticket.core.domain.seat.repository.PlaceRepository
@@ -48,7 +49,7 @@ class ReservationConcurrencyTest @Autowired constructor(
         val place = Place("고척스카이돔", "서울특별시 구로구 경인로 430")
         placeRepository.save(place)
         val seats = listOf("A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1", "I1", "J1", "K1").map {
-            Seat("S", it, 100000, 100L, place)
+            Seat(GradeType.S, it, 100000, 100L, place)
         }
         seatRepository.saveAll(seats)
 

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
@@ -1,15 +1,20 @@
 package com.example.enterparkticket.core.domain.reservation.service
 
+import com.example.enterparkticket.core.domain.performance.domain.AgeLimitType
+import com.example.enterparkticket.core.domain.performance.domain.Performance
+import com.example.enterparkticket.core.domain.performance.repository.PerformanceRepository
 import com.example.enterparkticket.core.domain.reservation.config.DomainSpringBootTest
 import com.example.enterparkticket.core.domain.reservation.config.RedisExtension
 import com.example.enterparkticket.core.domain.reservation.domain.TicketReceiptType
 import com.example.enterparkticket.core.domain.reservation.repository.ReservationRepository
 import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationDto
 import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationSeatDto
+import com.example.enterparkticket.core.domain.seat.domain.GradeSeat
 import com.example.enterparkticket.core.domain.seat.domain.GradeType
-import com.example.enterparkticket.core.domain.seat.domain.Place
+import com.example.enterparkticket.core.domain.place.domain.Place
 import com.example.enterparkticket.core.domain.seat.domain.Seat
-import com.example.enterparkticket.core.domain.seat.repository.PlaceRepository
+import com.example.enterparkticket.core.domain.place.repository.PlaceRepository
+import com.example.enterparkticket.core.domain.seat.repository.GradeSeatRepository
 import com.example.enterparkticket.core.domain.seat.repository.SeatRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.extensions.install
@@ -17,6 +22,7 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.testcontainers.perSpec
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -27,6 +33,8 @@ private val logger = KotlinLogging.logger {}
 @DomainSpringBootTest
 class ReservationConcurrencyTest @Autowired constructor(
     private val placeRepository: PlaceRepository,
+    private val performanceRepository: PerformanceRepository,
+    private val gradeSeatRepository: GradeSeatRepository,
     private val seatRepository: SeatRepository,
     private val reservationRepository: ReservationRepository,
 ) : BehaviorSpec({
@@ -48,8 +56,21 @@ class ReservationConcurrencyTest @Autowired constructor(
     Given("동시성 티켓 예매") {
         val place = Place("고척스카이돔", "서울특별시 구로구 경인로 430")
         placeRepository.save(place)
+        val performance = Performance(
+            "알라딘",
+            "이미지",
+            "설명",
+            LocalDate.of(2024, 12, 19),
+            LocalDate.of(2025, 1, 19),
+            120,
+            AgeLimitType.AGE_12,
+            1L
+        )
+        performanceRepository.save(performance)
+        val gradeSeat = GradeSeat(GradeType.S, 50, 100000, performance)
+        gradeSeatRepository.save(gradeSeat)
         val seats = listOf("A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1", "I1", "J1", "K1").map {
-            Seat(GradeType.S, it, 100000, 100L, place)
+            Seat(it, gradeSeat)
         }
         seatRepository.saveAll(seats)
 
@@ -57,7 +78,7 @@ class ReservationConcurrencyTest @Autowired constructor(
             val userId = 1L
             val successCounter = AtomicInteger()
             val seatsDto = listOf(CreateReservationSeatDto("A1"), CreateReservationSeatDto("K1"))
-            val dto = CreateReservationDto(100L, TicketReceiptType.DELIVERY, seatsDto)
+            val dto = CreateReservationDto(1L, TicketReceiptType.DELIVERY, seatsDto)
             repeat(nThreads) {
                 executorService.submit {
                     try {

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/reservation/service/ReservationConcurrencyTest.kt
@@ -3,7 +3,8 @@ package com.example.enterparkticket.core.domain.reservation.service
 import com.example.enterparkticket.core.domain.performance.domain.AgeLimitType
 import com.example.enterparkticket.core.domain.performance.domain.Performance
 import com.example.enterparkticket.core.domain.performance.repository.PerformanceRepository
-import com.example.enterparkticket.core.domain.performance.service.PerformanceDomainService
+import com.example.enterparkticket.core.domain.place.domain.Place
+import com.example.enterparkticket.core.domain.place.repository.PlaceRepository
 import com.example.enterparkticket.core.domain.reservation.config.DomainSpringBootTest
 import com.example.enterparkticket.core.domain.reservation.config.RedisExtension
 import com.example.enterparkticket.core.domain.reservation.domain.TicketReceiptType
@@ -12,9 +13,7 @@ import com.example.enterparkticket.core.domain.reservation.service.dto.CreateRes
 import com.example.enterparkticket.core.domain.reservation.service.dto.CreateReservationSeatDto
 import com.example.enterparkticket.core.domain.seat.domain.GradeSeat
 import com.example.enterparkticket.core.domain.seat.domain.GradeType
-import com.example.enterparkticket.core.domain.place.domain.Place
 import com.example.enterparkticket.core.domain.seat.domain.Seat
-import com.example.enterparkticket.core.domain.place.repository.PlaceRepository
 import com.example.enterparkticket.core.domain.seat.repository.GradeSeatRepository
 import com.example.enterparkticket.core.domain.seat.repository.SeatRepository
 import com.example.enterparkticket.core.domain.user.domain.GenderType
@@ -22,7 +21,6 @@ import com.example.enterparkticket.core.domain.user.domain.OAuthInfo
 import com.example.enterparkticket.core.domain.user.domain.OAuthProvider
 import com.example.enterparkticket.core.domain.user.domain.User
 import com.example.enterparkticket.core.domain.user.repository.UserRepository
-import com.example.enterparkticket.core.domain.user.service.UserDomainService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.extensions.install
 import io.kotest.core.spec.style.BehaviorSpec
@@ -56,22 +54,12 @@ class ReservationConcurrencyTest @Autowired constructor(
     lateinit var executorService: ExecutorService
     lateinit var countDownLatch: CountDownLatch
     lateinit var reservationDomainService: ReservationDomainService
-    lateinit var userDomainService: UserDomainService
-    lateinit var performanceDomainService: PerformanceDomainService
 
     beforeTest {
         executorService = Executors.newFixedThreadPool(nThreads)
         countDownLatch = CountDownLatch(nThreads)
-        userDomainService = UserDomainService(userRepository)
-        performanceDomainService = PerformanceDomainService(performanceRepository)
         reservationDomainService =
-            ReservationDomainService(
-                userDomainService,
-                performanceDomainService,
-                seatRepository,
-                reservationRepository,
-                publisher
-            )
+            ReservationDomainService(seatRepository, reservationRepository, publisher)
     }
 
     Given("동시성 티켓 예매") {

--- a/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/seat/domain/SeatTest.kt
+++ b/enterpark-ticket-core/domain/src/test/kotlin/com/example/enterparkticket/core/domain/seat/domain/SeatTest.kt
@@ -1,0 +1,37 @@
+package com.example.enterparkticket.core.domain.seat.domain
+
+import com.example.enterparkticket.core.domain.performance.domain.AgeLimitType
+import com.example.enterparkticket.core.domain.performance.domain.Performance
+import com.example.enterparkticket.core.domain.seat.exception.AlreadyReservedSeatException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import java.time.LocalDate
+
+class SeatTest : FunSpec({
+
+    context("validateIsReserved") {
+        val performance = Performance(
+            "알라딘",
+            "이미지",
+            "설명",
+            LocalDate.of(2024, 12, 19),
+            LocalDate.of(2025, 1, 19),
+            120,
+            AgeLimitType.AGE_12,
+            1L
+        )
+        val gradeSeat = GradeSeat(GradeType.S, 50, 100000, performance)
+
+        test("이미 예매된 좌석이라면 예외가 발생한다") {
+            val seat = Seat("A1", gradeSeat, true)
+            shouldThrow<AlreadyReservedSeatException> {
+                seat.validateIsReserved()
+            }
+        }
+
+        test("아직 예매되지 않은 좌석이면 예외가 발생하지 않는다") {
+            val seat = Seat("A1", gradeSeat, false)
+            seat.validateIsReserved()
+        }
+    }
+})

--- a/enterpark-ticket-core/domain/src/test/resources/application-test.yml
+++ b/enterpark-ticket-core/domain/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    primary:
+      jdbc-url: jdbc:tc:mysql:8.0.36:///test_db?TC_INITSCRIPT=db/init.sql
+      driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: 1234
+  flyway:
+    enabled: false

--- a/enterpark-ticket-core/domain/src/test/resources/application-test.yml
+++ b/enterpark-ticket-core/domain/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    primary:
+    test:
       jdbc-url: jdbc:tc:mysql:8.0.36:///test_db?TC_INITSCRIPT=db/init.sql
       driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
   jpa:

--- a/enterpark-ticket-core/domain/src/test/resources/application-test.yml
+++ b/enterpark-ticket-core/domain/src/test/resources/application-test.yml
@@ -12,6 +12,5 @@ spring:
     redis:
       host: localhost
       port: 6379
-      password: 1234
   flyway:
     enabled: false

--- a/enterpark-ticket-core/domain/src/test/resources/db/init.sql
+++ b/enterpark-ticket-core/domain/src/test/resources/db/init.sql
@@ -3,6 +3,7 @@ DROP TABLE IF EXISTS performance;
 DROP TABLE IF EXISTS schedule;
 DROP TABLE IF EXISTS casting;
 DROP TABLE IF EXISTS place;
+DROP TABLE IF EXISTS grade_seat;
 DROP TABLE IF EXISTS seat;
 DROP TABLE IF EXISTS reservation;
 
@@ -78,21 +79,31 @@ CREATE TABLE place
     created_by         VARCHAR(255) NULL,
     last_modified_by   VARCHAR(255) NULL
 );
+CREATE TABLE grade_seat
+(
+    grade_seat_id      BIGINT AUTO_INCREMENT PRIMARY KEY,
+    grade              VARCHAR(15)  NOT NULL,
+    seat_count         INT          NOT NULL,
+    price              INT          NOT NULL,
+    performance_id     BIGINT       NOT NULL,
+    created_date       TIMESTAMP(6) NULL,
+    last_modified_date TIMESTAMP(6) NULL,
+    deleted_date       TIMESTAMP(6) NULL,
+    created_by         VARCHAR(255) NULL,
+    last_modified_by   VARCHAR(255) NULL
+);
 CREATE TABLE seat
 (
     seat_id            BIGINT AUTO_INCREMENT PRIMARY KEY,
-    grade              VARCHAR(15)  NOT NULL,
     seat_number        VARCHAR(15)  NOT NULL,
-    price              INT          NOT NULL,
-    performance_id     BIGINT       NOT NULL,
+    grade_seat_id      BIGINT       NOT NULL,
     is_reserved        BOOLEAN      NOT NULL,
-    place_id           BIGINT       NOT NULL,
     created_date       TIMESTAMP(6) NULL,
     last_modified_date TIMESTAMP(6) NULL,
     deleted_date       TIMESTAMP(6) NULL,
     created_by         VARCHAR(255) NULL,
     last_modified_by   VARCHAR(255) NULL,
-    CONSTRAINT fk_place_seat FOREIGN KEY (place_id) REFERENCES place (place_id)
+    CONSTRAINT fk_grade_seat_seat FOREIGN KEY (grade_seat_id) REFERENCES grade_seat (grade_seat_id)
 );
 CREATE TABLE reservation
 (

--- a/enterpark-ticket-core/domain/src/test/resources/db/init.sql
+++ b/enterpark-ticket-core/domain/src/test/resources/db/init.sql
@@ -105,7 +105,7 @@ CREATE TABLE seat
     created_by         VARCHAR(255) NULL,
     last_modified_by   VARCHAR(255) NULL,
     CONSTRAINT fk_grade_seat_seat FOREIGN KEY (grade_seat_id) REFERENCES grade_seat (grade_seat_id),
-    INDEX idx_grade_seat_id_seat_number (grade_seat_id, seat_number)
+    UNIQUE unique_grade_seat_id_seat_number (grade_seat_id, seat_number)
 );
 CREATE TABLE reservation
 (

--- a/enterpark-ticket-core/domain/src/test/resources/db/init.sql
+++ b/enterpark-ticket-core/domain/src/test/resources/db/init.sql
@@ -1,0 +1,110 @@
+DROP TABLE IF EXISTS `user`;
+DROP TABLE IF EXISTS performance;
+DROP TABLE IF EXISTS schedule;
+DROP TABLE IF EXISTS casting;
+DROP TABLE IF EXISTS place;
+DROP TABLE IF EXISTS seat;
+DROP TABLE IF EXISTS reservation;
+
+CREATE TABLE `user`
+(
+    user_id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    oid                BIGINT       NOT NULL,
+    provider           VARCHAR(15)  NOT NULL,
+    name               VARCHAR(20)  NOT NULL,
+    email              VARCHAR(255) NOT NULL,
+    phone_number       VARCHAR(20)  NOT NULL,
+    birth_date         DATE         NOT NULL,
+    gender             VARCHAR(15)  NOT NULL,
+    address            VARCHAR(255) NULL,
+    role               VARCHAR(15)  NOT NULL,
+    state              VARCHAR(15)  NOT NULL,
+    created_date       TIMESTAMP(6) NULL,
+    last_modified_date TIMESTAMP(6) NULL,
+    deleted_date       TIMESTAMP(6) NULL
+);
+CREATE TABLE performance
+(
+    performance_id     BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title              VARCHAR(255) NOT NULL,
+    image_url          VARCHAR(255) NOT NULL,
+    description        VARCHAR(255) NOT NULL,
+    start_date         DATE         NOT NULL,
+    end_date           DATE         NOT NULL,
+    total_time         INT          NOT NULL,
+    age_limit          VARCHAR(15)  NOT NULL,
+    place_id           BIGINT       NOT NULL,
+    created_date       TIMESTAMP(6) NULL,
+    last_modified_date TIMESTAMP(6) NULL,
+    deleted_date       TIMESTAMP(6) NULL,
+    created_by         VARCHAR(255) NULL,
+    last_modified_by   VARCHAR(255) NULL
+);
+CREATE TABLE schedule
+(
+    schedule_id        BIGINT AUTO_INCREMENT PRIMARY KEY,
+    date_time          TIMESTAMP(6) NOT NULL,
+    sequence           INT          NOT NULL,
+    performance_id     BIGINT       NOT NULL,
+    created_date       TIMESTAMP(6) NULL,
+    last_modified_date TIMESTAMP(6) NULL,
+    deleted_date       TIMESTAMP(6) NULL,
+    created_by         VARCHAR(255) NULL,
+    last_modified_by   VARCHAR(255) NULL,
+    CONSTRAINT fk_performance_schedule FOREIGN KEY (performance_id) REFERENCES performance (performance_id)
+);
+CREATE TABLE casting
+(
+    casting_id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name               VARCHAR(15)  NOT NULL,
+    role               VARCHAR(20)  NOT NULL,
+    image_url          VARCHAR(255) NULL,
+    schedule_id        BIGINT       NOT NULL,
+    created_date       TIMESTAMP(6) NULL,
+    last_modified_date TIMESTAMP(6) NULL,
+    deleted_date       TIMESTAMP(6) NULL,
+    created_by         VARCHAR(255) NULL,
+    last_modified_by   VARCHAR(255) NULL,
+    CONSTRAINT fk_schedule_casting FOREIGN KEY (schedule_id) REFERENCES schedule (schedule_id)
+);
+CREATE TABLE place
+(
+    place_id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name               VARCHAR(255) NOT NULL,
+    address            VARCHAR(255) NOT NULL,
+    created_date       TIMESTAMP(6) NULL,
+    last_modified_date TIMESTAMP(6) NULL,
+    deleted_date       TIMESTAMP(6) NULL,
+    created_by         VARCHAR(255) NULL,
+    last_modified_by   VARCHAR(255) NULL
+);
+CREATE TABLE seat
+(
+    seat_id            BIGINT AUTO_INCREMENT PRIMARY KEY,
+    grade              VARCHAR(15)  NOT NULL,
+    seat_number        VARCHAR(15)  NOT NULL,
+    price              INT          NOT NULL,
+    performance_id     BIGINT       NOT NULL,
+    is_reserved        BOOLEAN      NOT NULL,
+    place_id           BIGINT       NOT NULL,
+    created_date       TIMESTAMP(6) NULL,
+    last_modified_date TIMESTAMP(6) NULL,
+    deleted_date       TIMESTAMP(6) NULL,
+    created_by         VARCHAR(255) NULL,
+    last_modified_by   VARCHAR(255) NULL,
+    CONSTRAINT fk_place_seat FOREIGN KEY (place_id) REFERENCES place (place_id)
+);
+CREATE TABLE reservation
+(
+    reservation_id     BIGINT AUTO_INCREMENT PRIMARY KEY,
+    state              VARCHAR(15)  NOT NULL,
+    ticket_receipt     VARCHAR(15)  NOT NULL,
+    user_id            BIGINT       NOT NULL,
+    performance_id     BIGINT       NOT NULL,
+    seat_id            BIGINT       NOT NULL,
+    created_date       TIMESTAMP(6) NULL,
+    last_modified_date TIMESTAMP(6) NULL,
+    deleted_date       TIMESTAMP(6) NULL,
+    created_by         VARCHAR(255) NULL,
+    last_modified_by   VARCHAR(255) NULL
+);

--- a/enterpark-ticket-core/domain/src/test/resources/db/init.sql
+++ b/enterpark-ticket-core/domain/src/test/resources/db/init.sql
@@ -90,7 +90,8 @@ CREATE TABLE grade_seat
     last_modified_date TIMESTAMP(6) NULL,
     deleted_date       TIMESTAMP(6) NULL,
     created_by         VARCHAR(255) NULL,
-    last_modified_by   VARCHAR(255) NULL
+    last_modified_by   VARCHAR(255) NULL,
+    INDEX idx_performance_id (performance_id)
 );
 CREATE TABLE seat
 (
@@ -103,7 +104,8 @@ CREATE TABLE seat
     deleted_date       TIMESTAMP(6) NULL,
     created_by         VARCHAR(255) NULL,
     last_modified_by   VARCHAR(255) NULL,
-    CONSTRAINT fk_grade_seat_seat FOREIGN KEY (grade_seat_id) REFERENCES grade_seat (grade_seat_id)
+    CONSTRAINT fk_grade_seat_seat FOREIGN KEY (grade_seat_id) REFERENCES grade_seat (grade_seat_id),
+    INDEX idx_grade_seat_id_seat_number (grade_seat_id, seat_number)
 );
 CREATE TABLE reservation
 (
@@ -117,5 +119,6 @@ CREATE TABLE reservation
     last_modified_date TIMESTAMP(6) NULL,
     deleted_date       TIMESTAMP(6) NULL,
     created_by         VARCHAR(255) NULL,
-    last_modified_by   VARCHAR(255) NULL
+    last_modified_by   VARCHAR(255) NULL,
+    INDEX idx_user_id_performance_id (user_id, performance_id)
 );


### PR DESCRIPTION
## 📌 개요
- close #11 

## 💾 작업사항
- 동시성 제어(여러 사용자가 동시에 예매할 경우) - 분산락 redisson 사용
- 한 사람당 한번 예매할 때 최대 10개 좌석 예매 가능
- kotest, test containers 사용하여 테스트 코드 구현
- 각 엔티티 구현

## 🌠 기타
- 분산락은 [카카오 페이 Kotlin AOP](https://tech.kakaopay.com/post/overcome-spring-aop-with-kotlin/) 자료를 참고해서 구현하였습니다.